### PR TITLE
Add smart auto stop indicator to Quick Settings Tile

### DIFF
--- a/android/app/src/main/kotlin/com/appshub/bettbox/services/BettboxTileService.kt
+++ b/android/app/src/main/kotlin/com/appshub/bettbox/services/BettboxTileService.kt
@@ -3,12 +3,14 @@ package com.appshub.bettbox.services
 import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.Intent
+import android.graphics.drawable.Icon
 import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.Observer
 import com.appshub.bettbox.GlobalState
+import com.appshub.bettbox.R
 import com.appshub.bettbox.RunState
 import com.appshub.bettbox.TempActivity
 
@@ -27,6 +29,14 @@ class BettboxTileService : TileService() {
                 RunState.PENDING -> Tile.STATE_UNAVAILABLE
                 RunState.STOP -> Tile.STATE_INACTIVE
             }
+            
+            val iconRes = if (runState == RunState.STOP && GlobalState.isSmartStopped) {
+                R.drawable.ic_tile_smart_stopped
+            } else {
+                R.drawable.ic_tile
+            }
+            qsTile.icon = Icon.createWithResource(this, iconRes)
+            
             qsTile.updateTile()
         }
     }

--- a/android/app/src/main/res/drawable-night/ic_tile_smart_stopped.xml
+++ b/android/app/src/main/res/drawable-night/ic_tile_smart_stopped.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <bitmap android:src="@drawable/ic_shortcut_white" />
+    </item>
+    <item
+        android:height="3dp"
+        android:width="3dp"
+        android:gravity="bottom|right">
+        <shape android:shape="oval">
+            <solid android:color="#FFFFFF" />
+        </shape>
+    </item>
+</layer-list>

--- a/android/app/src/main/res/drawable/ic_tile_smart_stopped.xml
+++ b/android/app/src/main/res/drawable/ic_tile_smart_stopped.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <bitmap android:src="@drawable/ic_shortcut_black" />
+    </item>
+    <item
+        android:height="3dp"
+        android:width="3dp"
+        android:gravity="bottom|right">
+        <shape android:shape="oval">
+            <solid android:color="#000000" />
+        </shape>
+    </item>
+</layer-list>


### PR DESCRIPTION
Add visual indicator on the tile icon when VPN is stopped by smart auto stop feature. This allows users to easily identify the smart stopped state directly from the control center.

- Add ic_tile_smart_stopped.xml drawable with a dot indicator
- Add night mode variant for dark theme support
- Update BettboxTileService to switch icon based on isSmartStopped state