### PR TITLE
Fix window close hang on macOS

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -575,14 +575,18 @@ class AppController {
   }
 
   Future<void> handleExit() async {
+    const exitTimeout = Duration(seconds: 5);
     try {
       stopWakelockAutoRecovery();
       await savePreferences();
       await Future.wait([
-        if (macOS != null) macOS!.updateDns(true),
-        if (proxy != null) proxy!.stopProxy(),
-        clashCore.shutdown(),
-        if (clashService != null) clashService!.destroy(),
+        if (macOS != null)
+          macOS!.updateDns(true).timeout(exitTimeout, onTimeout: () {}),
+        if (proxy != null)
+          proxy!.stopProxy().timeout(exitTimeout, onTimeout: () {}),
+        clashCore.shutdown().timeout(exitTimeout, onTimeout: () {}),
+        if (clashService != null)
+          clashService!.destroy().timeout(exitTimeout, onTimeout: () {}),
       ].whereType<Future<void>>().toList());
     } finally {
       system.exit();

--- a/lib/manager/window_manager.dart
+++ b/lib/manager/window_manager.dart
@@ -79,6 +79,7 @@ class _WindowContainerState extends ConsumerState<WindowManager>
 
   @override
   void onWindowClose() async {
+    globalState.appController.unBackBlock();
     await globalState.appController.handleBackOrExit();
   }
 


### PR DESCRIPTION
Fixes #68. The window wouldn't close on macOS because the exit handler was waiting indefinitely for some async operations. Added 5-second timeouts to prevent any of them from blocking the shutdown. Also had to unblock the back button state before handling the exit.