### PR TITLE
优化: 调整策略组卡片布局

### DIFF
--- a/lib/views/proxies/card.dart
+++ b/lib/views/proxies/card.dart
@@ -174,73 +174,105 @@ class ProxyCard extends StatelessWidget {
     return RepaintBoundary(
       child: Stack(
         children: [
-        Consumer(
-          builder: (_, ref, child) {
-            final selectedProxyName = ref.watch(
-              getSelectedProxyNameProvider(groupName),
-            );
-            return CommonCard(
-              onPressed: () {
-                _changeProxy(ref);
-              },
-              isSelected: selectedProxyName == proxy.name,
-              child: child!,
-            );
-          },
-          child: Container(
-            alignment: Alignment.centerLeft,
-            padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                proxyNameText,
-                const SizedBox(height: 8),
-                if (type == ProxyCardType.expand) ...[
-                  SizedBox(
-                    height: measure.bodySmallHeight,
-                    child: _ProxyDesc(proxy: proxy),
-                  ),
-                  const SizedBox(height: 6),
-                  delayText,
-                ] else
-                  SizedBox(
-                    height: measure.bodySmallHeight,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Flexible(
-                          flex: 1,
-                          child: TooltipText(
-                            text: Text(
-                              proxy.type,
-                              style: context.textTheme.bodySmall?.copyWith(
-                                overflow: TextOverflow.ellipsis,
-                                color: context
-                                    .textTheme
-                                    .bodySmall
-                                    ?.color
-                                    ?.opacity80,
+          Consumer(
+            builder: (_, ref, child) {
+              final selectedProxyName = ref.watch(
+                getSelectedProxyNameProvider(groupName),
+              );
+              return CommonCard(
+                onPressed: () {
+                  _changeProxy(ref);
+                },
+                isSelected: selectedProxyName == proxy.name,
+                child: child!,
+              );
+            },
+            child: Container(
+              alignment: Alignment.centerLeft,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 8,
+                children: [
+                  proxyNameText,
+                  if (type == ProxyCardType.expand) ...[
+                    SizedBox(
+                      height: measure.labelSmallHeight * 2 + 4,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        spacing: 4,
+                        children: [
+                          SizedBox(
+                            height: measure.labelSmallHeight,
+                            child: _ProxyDesc(proxy: proxy),
+                          ),
+                          SizedBox(
+                            height: measure.labelSmallHeight,
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.end,
+                              spacing: 4,
+                              children: [
+                                Expanded(
+                                  child: Text(
+                                    proxy.type,
+                                    style: context.textTheme.bodySmall
+                                        ?.copyWith(
+                                          overflow: TextOverflow.ellipsis,
+                                          color: context
+                                              .textTheme
+                                              .bodySmall
+                                              ?.color
+                                              ?.opacity80,
+                                        ),
+                                  ),
+                                ),
+                                delayText,
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ] else
+                    SizedBox(
+                      height: measure.bodySmallHeight,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Flexible(
+                            flex: 1,
+                            child: TooltipText(
+                              text: Text(
+                                proxy.type,
+                                style: context.textTheme.bodySmall?.copyWith(
+                                  overflow: TextOverflow.ellipsis,
+                                  color: context
+                                      .textTheme
+                                      .bodySmall
+                                      ?.color
+                                      ?.opacity80,
+                                ),
                               ),
                             ),
                           ),
-                        ),
-                        delayText,
-                      ],
+                          delayText,
+                        ],
+                      ),
                     ),
-                  ),
-              ],
+                ],
+              ),
             ),
           ),
-        ),
-        if (groupType.isComputedSelected)
-          Positioned(
-            top: 0,
-            right: 0,
-            child: _ProxyComputedMark(groupName: groupName, proxy: proxy),
-          ),
-      ],
+          if (groupType.isComputedSelected)
+            Positioned(
+              top: 0,
+              right: 0,
+              child: _ProxyComputedMark(groupName: groupName, proxy: proxy),
+            ),
+        ],
       ),
     );
   }
@@ -253,12 +285,33 @@ class _ProxyDesc extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final desc = ref.watch(getProxyDescProvider(proxy));
-    return EmojiText(
-      desc,
-      overflow: TextOverflow.ellipsis,
-      style: context.textTheme.bodySmall?.copyWith(
-        color: context.textTheme.bodySmall?.color?.opacity80,
+    final group = ref.watch(
+      groupsProvider.select((groups) => groups.getGroup(proxy.name)),
+    );
+    if (group == null) return const SizedBox.shrink();
+    final selectedName = ref
+        .watch(getProxyCardStateProvider(proxy.name))
+        .proxyName;
+    if (selectedName.isEmpty) return const SizedBox.shrink();
+    final colorScheme = context.colorScheme;
+    return Ink(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 1),
+      decoration: ShapeDecoration(
+        color: colorScheme.surfaceContainerHighest.opacity50,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(6),
+          side: BorderSide(color: colorScheme.outlineVariant.opacity30),
+        ),
+      ),
+      child: Text(
+        selectedName,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: context.textTheme.labelSmall?.copyWith(
+          height: 1,
+          color: colorScheme.onSurfaceVariant.opacity80,
+          fontWeight: FontWeight.w400,
+        ),
       ),
     );
   }

--- a/lib/views/proxies/card.dart
+++ b/lib/views/proxies/card.dart
@@ -215,17 +215,9 @@ class ProxyCard extends StatelessWidget {
                               spacing: 4,
                               children: [
                                 Expanded(
-                                  child: Text(
-                                    proxy.type,
-                                    style: context.textTheme.bodySmall
-                                        ?.copyWith(
-                                          overflow: TextOverflow.ellipsis,
-                                          color: context
-                                              .textTheme
-                                              .bodySmall
-                                              ?.color
-                                              ?.opacity80,
-                                        ),
+                                  child: Align(
+                                    alignment: Alignment.centerLeft,
+                                    child: _ProxyMetaTag(proxy.type),
                                   ),
                                 ),
                                 delayText,
@@ -293,6 +285,17 @@ class _ProxyDesc extends ConsumerWidget {
         .watch(getProxyCardStateProvider(proxy.name))
         .proxyName;
     if (selectedName.isEmpty) return const SizedBox.shrink();
+    return _ProxyMetaTag(selectedName);
+  }
+}
+
+class _ProxyMetaTag extends StatelessWidget {
+  final String text;
+
+  const _ProxyMetaTag(this.text);
+
+  @override
+  Widget build(BuildContext context) {
     final colorScheme = context.colorScheme;
     return Ink(
       padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 1),
@@ -304,7 +307,7 @@ class _ProxyDesc extends ConsumerWidget {
         ),
       ),
       child: Text(
-        selectedName,
+        text,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
         style: context.textTheme.labelSmall?.copyWith(

--- a/lib/views/proxies/common.dart
+++ b/lib/views/proxies/common.dart
@@ -14,7 +14,7 @@ double getItemHeight(ProxyCardType proxyCardType) {
   final baseHeight =
       16 + measure.bodyMediumHeight * 2 + measure.bodySmallHeight + 8 + 4;
   return switch (proxyCardType) {
-    ProxyCardType.expand => baseHeight + measure.labelSmallHeight + 6,
+    ProxyCardType.expand => baseHeight - measure.bodySmallHeight + measure.labelSmallHeight * 2 + 4,
     ProxyCardType.shrink => baseHeight,
     ProxyCardType.min => baseHeight - measure.bodyMediumHeight,
   };

--- a/lib/widgets/scroll.dart
+++ b/lib/widgets/scroll.dart
@@ -22,13 +22,14 @@ class CommonScrollBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final hasController = controller != null;
     return Scrollbar(
       controller: controller,
-      thumbVisibility: thumbVisibility,
-      trackVisibility: trackVisibility,
+      thumbVisibility: hasController ? thumbVisibility : false,
+      trackVisibility: hasController ? trackVisibility : false,
       thickness: 8,
       radius: const Radius.circular(8),
-      interactive: true,
+      interactive: hasController,
       child: child,
     );
   }


### PR DESCRIPTION
Resolve #91 
调整标准尺寸下的策略组卡片布局
|修改前|修改后|
|--|--|
|<img width="719" height="1597" alt="image" src="https://github.com/user-attachments/assets/d459cea1-82c7-4e1f-b4b9-d9fa1454e9bc" />|<img width="719" height="1597" alt="image" src="https://github.com/user-attachments/assets/378caa4b-e3da-478a-8575-f50f90af9a25" />|