### PR TITLE
feat(tray): improve macOS speed test submenu behavior

### DIFF
--- a/lib/common/tray.dart
+++ b/lib/common/tray.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:bett_box/enum/enum.dart';
 import 'package:bett_box/models/models.dart';
+import 'package:bett_box/providers/providers.dart';
+import 'package:bett_box/providers/proxy_delay_provider.dart';
 import 'package:bett_box/state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -15,214 +18,242 @@ class Tray {
   Timer? _debounceTimer;
   TrayState? _pendingState;
   bool _isUpdating = false;
+  bool _pendingFocus = false;
 
   static const _debounceDelay = Duration(milliseconds: 300);
-  Future _updateSystemTray({
-    required Brightness? brightness,
-    required bool isStart,
-    bool force = false,
-  }) async {
-    if (system.isAndroid) {
-      return;
-    }
-    if (force) {
-      await trayManager.destroy();
-    }
+
+  Future<void> _updateSystemTray({required Brightness? brightness, required bool isStart, bool force = false}) async {
+    if (system.isAndroid) return;
+    if (force) await trayManager.destroy();
     await trayManager.setIcon(
       utils.getTrayIconPath(
-        brightness:
-            brightness ??
-            WidgetsBinding.instance.platformDispatcher.platformBrightness,
+        brightness: brightness ?? WidgetsBinding.instance.platformDispatcher.platformBrightness,
         isStart: isStart,
       ),
       isTemplate: system.isMacOS,
     );
-    if (!Platform.isLinux) {
-      await trayManager.setToolTip(appName);
-    }
+    if (!Platform.isLinux) await trayManager.setToolTip(appName);
   }
 
-  Future<void> update({
-    required TrayState trayState,
-    bool focus = false,
-  }) async {
-    if (system.isAndroid) {
-      return;
-    }
+  Future<void> update({required TrayState trayState, bool focus = false}) async {
+    if (system.isAndroid) return;
 
     _debounceTimer?.cancel();
 
     if (_isUpdating) {
       _pendingState = trayState;
+      _pendingFocus = _pendingFocus || focus;
       return;
     }
 
     if (focus) {
-      await _doUpdate(trayState: trayState, focus: focus);
+      await _doUpdate(trayState: trayState, focus: true);
     } else {
       _debounceTimer = Timer(_debounceDelay, () async {
-        await _doUpdate(trayState: trayState, focus: focus);
+        await _doUpdate(trayState: trayState, focus: false);
       });
     }
   }
 
-  Future<void> _doUpdate({
-    required TrayState trayState,
-    bool focus = false,
-  }) async {
+  Future<void> _doUpdate({required TrayState trayState, bool focus = false}) async {
     if (_isUpdating) return;
     _isUpdating = true;
 
     try {
       if (!Platform.isLinux) {
-        await _updateSystemTray(
-          brightness: trayState.brightness,
-          isStart: trayState.isStart,
-          force: focus,
-        );
+        await _updateSystemTray(brightness: trayState.brightness, isStart: trayState.isStart, force: false);
       }
-    List<MenuItem> menuItems = [];
-    final showMenuItem = MenuItem(
-      label: appLocalizations.show,
-      onClick: (_) {
-        window?.show();
-      },
-    );
-    menuItems.add(showMenuItem);
-    final startMenuItem = MenuItem.checkbox(
-      label: trayState.isStart ? appLocalizations.stop : appLocalizations.start,
-      onClick: (_) async {
-        globalState.appController.updateStart();
-      },
-      checked: false,
-    );
-    menuItems.add(startMenuItem);
-    menuItems.add(MenuItem.separator());
-    for (final mode in Mode.values) {
+
+      final List<MenuItem> menuItems = [];
+
       menuItems.add(
-        MenuItem.checkbox(
-          label: Intl.message(mode.name),
+        MenuItem(
+          label: appLocalizations.show,
           onClick: (_) {
-            globalState.appController.changeMode(mode);
+            window?.show();
           },
-          checked: mode == trayState.mode,
-        ),
-      );
-    }
-    menuItems.add(MenuItem.separator());
-    if (system.isMacOS) {
-      for (final group in trayState.groups) {
-        List<MenuItem> subMenuItems = [];
-        for (final proxy in group.all) {
-          subMenuItems.add(
-            MenuItem.checkbox(
-              label: proxy.name,
-              checked: trayState.selectedMap[group.name] == proxy.name,
-              onClick: (_) {
-                final appController = globalState.appController;
-                appController.updateCurrentSelectedMap(group.name, proxy.name);
-                appController.changeProxy(
-                  groupName: group.name,
-                  proxyName: proxy.name,
-                );
-              },
-            ),
-          );
-        }
-        menuItems.add(
-          MenuItem.submenu(
-            label: group.name,
-            submenu: Menu(items: subMenuItems),
-          ),
-        );
-      }
-      if (trayState.groups.isNotEmpty) {
-        menuItems.add(MenuItem.separator());
-      }
-    }
-    if (trayState.isStart) {
-      menuItems.add(
-        MenuItem.checkbox(
-          label: appLocalizations.tun,
-          onClick: (_) {
-            globalState.appController.updateTun();
-          },
-          checked: trayState.tunEnable,
         ),
       );
       menuItems.add(
         MenuItem.checkbox(
-          label: appLocalizations.systemProxy,
-          onClick: (_) {
-            globalState.appController.updateSystemProxy();
+          label: trayState.isStart ? appLocalizations.stop : appLocalizations.start,
+          onClick: (_) async {
+            globalState.appController.updateStart();
           },
-          checked: trayState.systemProxy,
+          checked: false,
         ),
       );
       menuItems.add(MenuItem.separator());
-    }
-    final autoStartMenuItem = MenuItem.checkbox(
-      label: appLocalizations.autoLaunch,
-      onClick: (_) async {
-        globalState.appController.updateAutoLaunch();
-      },
-      checked: trayState.autoLaunch,
-    );
-    final copyEnvVarMenuItem = MenuItem(
-      label: appLocalizations.copyEnvVar,
-      onClick: (_) async {
-        await _copyEnv(trayState.port);
-      },
-    );
-    menuItems.add(autoStartMenuItem);
-    menuItems.add(copyEnvVarMenuItem);
 
-    if (!system.isAndroid) {
-      final wakelockMenuItem = MenuItem.checkbox(
-        label: appLocalizations.wakelock,
-        onClick: (_) async {
-          await _toggleWakelock();
-        },
-        checked: trayState.wakelockEnabled,
-      );
-      menuItems.add(wakelockMenuItem);
-    }
+      for (final mode in Mode.values) {
+        menuItems.add(
+          MenuItem.checkbox(
+            label: Intl.message(mode.name),
+            onClick: (_) {
+              globalState.appController.changeMode(mode);
+            },
+            checked: mode == trayState.mode,
+          ),
+        );
+      }
+      menuItems.add(MenuItem.separator());
 
-    menuItems.add(MenuItem.separator());
-    final exitMenuItem = MenuItem(
-      label: appLocalizations.exit,
-      onClick: (_) async {
-        await globalState.appController.handleExit();
-      },
-    );
-    menuItems.add(exitMenuItem);
-    final menu = Menu(items: menuItems);
-    await trayManager.setContextMenu(menu);
-    if (Platform.isLinux) {
-      await _updateSystemTray(
-        brightness: trayState.brightness,
-        isStart: trayState.isStart,
-        force: focus,
+      if (system.isMacOS) {
+        final delayNotifier = globalState.appController.ref.read(proxyDelayNotifierProvider.notifier);
+
+        for (final group in trayState.groups) {
+          // 直接从 state 读取，Riverpod 管理，不会因 rebuild 丢失
+          final groupDelays = delayNotifier.getGroupDelays(group.name);
+          final testState = delayNotifier.getGroupState(group.name);
+
+          // ── 复制并排序节点列表：低延迟在前，timeout/null 在后，DIRECT 永远最后 ──
+          final proxies = List<Proxy>.of(group.all)
+            ..sort((a, b) {
+              final delayA = groupDelays[a.name];
+              final delayB = groupDelays[b.name];
+
+              final isDirectA = a.name.toUpperCase().contains('DIRECT');
+              final isDirectB = b.name.toUpperCase().contains('DIRECT');
+              if (isDirectA != isDirectB) return isDirectA ? 1 : -1;
+
+              int norm(int? d) => (d == null || d < 0) ? 1 << 30 : d;
+              final diff = norm(delayA).compareTo(norm(delayB));
+              if (diff != 0) return diff;
+              return a.name.compareTo(b.name);
+            });
+
+          final List<MenuItem> subMenuItems = [];
+
+          // ── 测速按钮（顶部）──
+          subMenuItems.add(
+            MenuItem(
+              label: switch (testState) {
+                DelayTestState.idle => '⚡ 延迟测速',
+                DelayTestState.testing => '⏱ 测速中...',
+                DelayTestState.done => '⚡ 重新测速',
+              },
+              disabled: testState == DelayTestState.testing,
+              onClick: testState == DelayTestState.testing ? null : (_) => delayNotifier.testGroupDelay(group.name),
+            ),
+          );
+          subMenuItems.add(MenuItem.separator());
+
+          // ── 节点列表（排序后）──
+          for (final proxy in proxies) {
+            final delay = groupDelays[proxy.name];
+            final isSelected = trayState.selectedMap[group.name] == proxy.name;
+
+            subMenuItems.add(
+              MenuItem.checkbox(
+                label: _buildNodeLabel(proxy.name, delay),
+                checked: isSelected,
+                onClick: (_) {
+                  final c = globalState.appController;
+                  c.updateCurrentSelectedMap(group.name, proxy.name);
+                  c.changeProxy(groupName: group.name, proxyName: proxy.name);
+                },
+              ),
+            );
+          }
+
+          // ── 父菜单：组名 / 当前选中节点 ──
+          final currentNode = trayState.selectedMap[group.name] ?? '';
+          menuItems.add(
+            MenuItem.submenu(
+              label: _buildGroupLabel(group.name, currentNode),
+              submenu: Menu(items: subMenuItems),
+            ),
+          );
+        }
+
+        if (trayState.groups.isNotEmpty) menuItems.add(MenuItem.separator());
+      }
+
+      if (trayState.isStart) {
+        menuItems.add(
+          MenuItem.checkbox(
+            label: appLocalizations.tun,
+            onClick: (_) {
+              globalState.appController.updateTun();
+            },
+            checked: trayState.tunEnable,
+          ),
+        );
+        menuItems.add(
+          MenuItem.checkbox(
+            label: appLocalizations.systemProxy,
+            onClick: (_) {
+              globalState.appController.updateSystemProxy();
+            },
+            checked: trayState.systemProxy,
+          ),
+        );
+        menuItems.add(MenuItem.separator());
+      }
+
+      menuItems.add(
+        MenuItem.checkbox(
+          label: appLocalizations.autoLaunch,
+          onClick: (_) async {
+            globalState.appController.updateAutoLaunch();
+          },
+          checked: trayState.autoLaunch,
+        ),
       );
-    }
+      menuItems.add(
+        MenuItem(
+          label: appLocalizations.copyEnvVar,
+          onClick: (_) async {
+            await _copyEnv(trayState.port);
+          },
+        ),
+      );
+
+      if (!system.isAndroid) {
+        menuItems.add(
+          MenuItem.checkbox(
+            label: appLocalizations.wakelock,
+            onClick: (_) async {
+              await _toggleWakelock();
+            },
+            checked: trayState.wakelockEnabled,
+          ),
+        );
+      }
+
+      menuItems.add(MenuItem.separator());
+      menuItems.add(
+        MenuItem(
+          label: appLocalizations.exit,
+          onClick: (_) async {
+            await globalState.appController.handleExit();
+          },
+        ),
+      );
+
+      await trayManager.setContextMenu(Menu(items: menuItems));
+
+      if (Platform.isLinux) {
+        await _updateSystemTray(brightness: trayState.brightness, isStart: trayState.isStart, force: focus);
+      }
     } finally {
       _isUpdating = false;
-
       if (_pendingState != null) {
-        final pending = _pendingState;
+        final pending = _pendingState!;
+        final pendingFocus = _pendingFocus;
         _pendingState = null;
-        await _doUpdate(trayState: pending!, focus: false);
+        _pendingFocus = false;
+        await _doUpdate(trayState: pending, focus: pendingFocus);
       }
     }
   }
 
   Future<void> _copyEnv(int port) async {
-    final url = 'http://127.0.0.1:$port';
-
+    final httpUrl = 'http://127.0.0.1:$port';
+    final socksUrl = 'socks5://127.0.0.1:$port';
     final cmdline = system.isWindows
-        ? 'set \$env:all_proxy=$url'
-        : 'export all_proxy=$url';
-
+        ? '\$env:https_proxy="$httpUrl"; \$env:http_proxy="$httpUrl"; \$env:all_proxy="$socksUrl"'
+        : 'export https_proxy=$httpUrl;export http_proxy=$httpUrl;export all_proxy=$socksUrl';
     await Clipboard.setData(ClipboardData(text: cmdline));
   }
 
@@ -241,6 +272,23 @@ class Tray {
     } catch (e) {
       commonPrint.log('WakeLock toggle error: $e');
     }
+  }
+
+  String _delayTag(int? delay) {
+    if (delay == null) return '';
+    if (delay < 0) return 'timeout';
+    return '${delay}ms';
+  }
+
+  String _buildNodeLabel(String nodeName, int? delay) {
+    final tag = _delayTag(delay);
+    if (tag.isEmpty) return nodeName;
+    return '$nodeName  $tag';
+  }
+
+  String _buildGroupLabel(String groupName, String currentNode) {
+    if (currentNode.isEmpty) return groupName;
+    return '$groupName / $currentNode';
   }
 }
 

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -32,6 +32,8 @@ class AppController {
   final BuildContext context;
   final WidgetRef _ref;
 
+  WidgetRef get ref => _ref;
+  
   Timer? _wakelockSyncTimer;
   Completer<void>? _restartLock;
   Completer<void>? _exitLock;

--- a/lib/manager/tray_manager.dart
+++ b/lib/manager/tray_manager.dart
@@ -1,4 +1,5 @@
 import 'package:bett_box/common/common.dart';
+import 'package:bett_box/providers/proxy_delay_provider.dart';
 import 'package:bett_box/providers/state.dart';
 import 'package:bett_box/state.dart';
 import 'package:flutter/material.dart';
@@ -19,17 +20,28 @@ class _TrayContainerState extends ConsumerState<TrayManager> with TrayListener {
   void initState() {
     super.initState();
     trayManager.addListener(this);
+
+    // trayState 变化（模式切换、节点切换等）：走 debounce 普通刷新
     ref.listenManual(trayStateProvider, (prev, next) {
-      if (prev != next) {
-        globalState.appController.updateTray();
-      }
+      if (prev != next) globalState.appController.updateTray(false);
+    });
+
+    // 测速状态/结果变化：
+    // testing 状态变化 → 立即刷新（跳过 debounce），确保下次打开菜单即见"测速中..."
+    // done 状态变化   → 走 debounce 正常刷新
+    ref.listenManual(proxyDelayNotifierProvider, (prev, next) {
+      if (prev == next) return;
+
+      final hasNewTesting = next.entries.any(
+        (e) => e.value.testState == DelayTestState.testing && prev?[e.key]?.testState != DelayTestState.testing,
+      );
+
+      globalState.appController.updateTray(hasNewTesting);
     });
   }
 
   @override
-  Widget build(BuildContext context) {
-    return widget.child;
-  }
+  Widget build(BuildContext context) => widget.child;
 
   @override
   void onTrayIconRightMouseDown() {
@@ -38,17 +50,12 @@ class _TrayContainerState extends ConsumerState<TrayManager> with TrayListener {
   }
 
   @override
-  void onTrayMenuItemClick(MenuItem menuItem) {
-    super.onTrayMenuItemClick(menuItem);
-  }
-
-  @override
-  onTrayIconMouseDown() {
+  void onTrayIconMouseDown() {
     window?.show();
   }
 
   @override
-  dispose() {
+  void dispose() {
     trayManager.removeListener(this);
     super.dispose();
   }

--- a/lib/models/generated/clash_config.freezed.dart
+++ b/lib/models/generated/clash_config.freezed.dart
@@ -3223,7 +3223,7 @@ return $default(_that.mmdb,_that.asn,_that.geoip,_that.geosite);case _:
 @JsonSerializable()
 
 class _GeoXUrl implements GeoXUrl {
-  const _GeoXUrl({this.mmdb = 'https://cdn.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country-only-cn-private.mmdb', this.asn = 'https://cdn.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country-asn.mmdb', this.geoip = 'https://fastly.jsdelivr.net/gh/appshubcc/bett-rules@release/geoip.dat', this.geosite = 'https://cdn.jsdelivr.net/gh/Loyalsoldier/v2ray-rules-dat@release/geosite.dat'});
+  const _GeoXUrl({this.mmdb = 'https://fastly.jsdelivr.net/gh/appshubcc/bett-rules@release/geoip.metadb', this.asn = 'https://fastly.jsdelivr.net/gh/appshubcc/bett-rules@release/GeoLite2-ASN.mmdb', this.geoip = 'https://fastly.jsdelivr.net/gh/appshubcc/bett-rules@release/geoip.dat', this.geosite = 'https://fastly.jsdelivr.net/gh/appshubcc/bett-rules@release/geosite.dat'});
   factory _GeoXUrl.fromJson(Map<String, dynamic> json) => _$GeoXUrlFromJson(json);
 
 @override@JsonKey() final  String mmdb;

--- a/lib/models/generated/profile.freezed.dart
+++ b/lib/models/generated/profile.freezed.dart
@@ -1117,7 +1117,7 @@ return $default(_that.type,_that.overrideRules,_that.addedRules);case _:
 @JsonSerializable()
 
 class _OverrideRule implements OverrideRule {
-  const _OverrideRule({this.type = OverrideRuleType.added, final  List<Rule> overrideRules = const [], final  List<Rule> addedRules = const []}): _overrideRules = overrideRules,_addedRules = addedRules;
+  const _OverrideRule({this.type = OverrideRuleType.override, final  List<Rule> overrideRules = const [], final  List<Rule> addedRules = const []}): _overrideRules = overrideRules,_addedRules = addedRules;
   factory _OverrideRule.fromJson(Map<String, dynamic> json) => _$OverrideRuleFromJson(json);
 
 @override@JsonKey() final  OverrideRuleType type;

--- a/lib/models/generated/profile.g.dart
+++ b/lib/models/generated/profile.g.dart
@@ -81,7 +81,7 @@ _OverrideRule _$OverrideRuleFromJson(Map<String, dynamic> json) =>
     _OverrideRule(
       type:
           $enumDecodeNullable(_$OverrideRuleTypeEnumMap, json['type']) ??
-          OverrideRuleType.added,
+          OverrideRuleType.override,
       overrideRules:
           (json['overrideRules'] as List<dynamic>?)
               ?.map((e) => Rule.fromJson(e as Map<String, dynamic>))

--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -1,3 +1,4 @@
 export 'app.dart';
 export 'config.dart';
 export 'state.dart';
+export 'proxy_delay_provider.dart';

--- a/lib/providers/proxy_delay_provider.dart
+++ b/lib/providers/proxy_delay_provider.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:bett_box/clash/clash.dart';
+import 'package:bett_box/common/common.dart';
+import 'package:bett_box/state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'generated/proxy_delay_provider.g.dart';
+
+enum DelayTestState { idle, testing, done }
+
+/// 每个代理组的完整状态，delays 和 testState 都由 Riverpod 统一管理，
+/// 不再使用实例变量，避免 Riverpod rebuild 时数据丢失。
+class GroupDelayState {
+  final DelayTestState testState;
+  final Map<String, int> delays;
+
+  const GroupDelayState({this.testState = DelayTestState.idle, this.delays = const {}});
+
+  GroupDelayState copyWith({DelayTestState? testState, Map<String, int>? delays}) {
+    return GroupDelayState(testState: testState ?? this.testState, delays: delays ?? this.delays);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GroupDelayState && testState == other.testState && _mapEquals(delays, other.delays);
+
+  @override
+  int get hashCode => testState.hashCode ^ delays.hashCode;
+
+  static bool _mapEquals(Map<String, int> a, Map<String, int> b) {
+    if (a.length != b.length) return false;
+    for (final k in a.keys) {
+      if (a[k] != b[k]) return false;
+    }
+    return true;
+  }
+}
+
+@riverpod
+class ProxyDelayNotifier extends _$ProxyDelayNotifier {
+  @override
+  Map<String, GroupDelayState> build() => {};
+
+  DelayTestState getGroupState(String groupName) => state[groupName]?.testState ?? DelayTestState.idle;
+
+  /// 返回该组所有节点的延迟 map，key=节点名，value=ms（-1 表示 timeout）
+  Map<String, int> getGroupDelays(String groupName) => state[groupName]?.delays ?? {};
+
+  bool _isDirectNode(Map<String, dynamic>? nodeInfo, String nodeName) {
+    final type = (nodeInfo?['type'] as String? ?? '').toLowerCase();
+    return type == 'direct' || nodeName.toUpperCase() == 'DIRECT';
+  }
+
+  // 仅对 Selector 和 URLTest 都支持手动触发后自动切换，在测速完成后自动切换到延迟最低的节点。
+  // Fallback / LoadBalance / Relay 仍由内核自己管理
+  Future<void> _autoSelectBestNode(String groupName, Map<String, int> delays, Map<String, dynamic> proxiesRaw) async {
+    final groupInfo = proxiesRaw[groupName] as Map<String, dynamic>?;
+    final groupType = groupInfo?['type'] as String? ?? '';
+
+    const autoSelectTypes = {'Selector', 'URLTest'};
+    if (!autoSelectTypes.contains(groupType)) return;
+
+    final validEntries = delays.entries.where((e) => !e.key.toUpperCase().contains('DIRECT') && e.value > 0).toList();
+
+    if (validEntries.isEmpty) return;
+
+    validEntries.sort((a, b) => a.value.compareTo(b.value));
+    final bestNode = validEntries.first.key;
+    final bestMs = validEntries.first.value;
+
+    final c = globalState.appController;
+    c.updateCurrentSelectedMap(groupName, bestNode);
+    await c.changeProxy(groupName: groupName, proxyName: bestNode);
+    commonPrint.log('autoSelect[$groupName/${groupType}] → $bestNode (${bestMs}ms)');
+  }
+
+  Future<void> testGroupDelay(String groupName) async {
+    // 防重入：该组正在测速时直接返回
+    if (state[groupName]?.testState == DelayTestState.testing) return;
+
+    // 保留旧延迟数据，只更新 testState → testing
+    // state 变化会触发 tray_manager 监听器立即刷新菜单（"测速中..."）
+    state = Map.of(state)
+      ..[groupName] = GroupDelayState(testState: DelayTestState.testing, delays: state[groupName]?.delays ?? {});
+
+    Map<String, int> newDelays = {};
+    // 提升到方法级，供 finally 块复用，避免二次网络请求
+    Map<String, dynamic> proxiesRaw = {};
+
+    try {
+      final raw = await clashService?.getProxies() ?? {};
+      proxiesRaw = Map<String, dynamic>.from(raw);
+      final group = proxiesRaw[groupName] as Map<String, dynamic>?;
+      if (group == null) return;
+
+      final members = (group['all'] as List?)?.cast<String>() ?? [];
+
+      final proxyTestUrl = (group['testUrl'] as String?)?.isNotEmpty == true
+          ? group['testUrl'] as String
+          : 'https://www.gstatic.com/generate_204';
+
+      const directTestUrl = 'http://connectivitycheck.platform.hicloud.com/generate_204';
+
+      final entries = await Future.wait(
+        members.map((node) async {
+          final nodeInfo = proxiesRaw[node] as Map<String, dynamic>?;
+          final nodeType = nodeInfo?['type'] as String? ?? '';
+
+          final isGroup = const {'Selector', 'Fallback', 'URLTest', 'LoadBalance', 'Relay'}.contains(nodeType);
+
+          // 子节点是组类型（如 Fallback / URLTest）：测其当前激活节点
+          if (isGroup) {
+            final now = nodeInfo?['now'] as String?;
+            if (now != null) {
+              final nowInfo = proxiesRaw[now] as Map<String, dynamic>?;
+              final url = _isDirectNode(nowInfo, now) ? directTestUrl : proxyTestUrl;
+              final raw = await clashService?.asyncTestDelay(url, now) ?? '';
+              final decoded = jsonDecode(raw) as Map<String, dynamic>;
+              final ms = (decoded['value'] as num?)?.toInt() ?? -1;
+              return MapEntry(node, ms);
+            }
+            return MapEntry(node, -1);
+          }
+
+          // 普通叶子节点
+          final url = _isDirectNode(nodeInfo, node) ? directTestUrl : proxyTestUrl;
+          final raw = await clashService?.asyncTestDelay(url, node) ?? '';
+          final decoded = jsonDecode(raw) as Map<String, dynamic>;
+          final ms = (decoded['value'] as num?)?.toInt() ?? -1;
+          return MapEntry(node, ms);
+        }),
+      );
+
+      newDelays = Map.fromEntries(entries);
+    } catch (e) {
+      commonPrint.log('testGroupDelay[$groupName] error: $e');
+      // 异常时保留旧延迟数据，避免数据清空
+      newDelays = state[groupName]?.delays ?? {};
+    } finally {
+      // 先切换最优节点，确保 selectedMap 先更新
+      if (newDelays.isNotEmpty && proxiesRaw.isNotEmpty) {
+        await _autoSelectBestNode(groupName, newDelays, proxiesRaw);
+      }
+      // 再更新延迟 state → done，触发 tray 刷新
+      // 此时 selectedMap 已经是新节点，父菜单能正确显示 "组名 / 最优节点"
+      state = Map.of(state)..[groupName] = GroupDelayState(testState: DelayTestState.done, delays: newDelays);
+    }
+  }
+}

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>FLTDisableImpeller</key>
+	<false/>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -857,18 +857,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: "direct main"
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   menu_base:
     dependency: transitive
     description:
@@ -881,10 +881,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1413,10 +1413,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   flutter_riverpod: ^2.6.1
   riverpod_annotation: ^2.6.1
   riverpod: ^2.6.1
-  material_color_utilities: ^0.11.1
+  material_color_utilities: ^0.13.0
   flutter_js: ^0.8.7
   flutter_svg: ^2.2.4
   xml: ^6.5.0


### PR DESCRIPTION
## Summary
Improve macOS tray submenu behavior for proxy group speed testing.

## Changes
- Add per-group delay state management for tray submenu
- Show `延迟测速 -> 测速中... -> 重新测速` state transitions
- Sort submenu nodes by delay after testing, with DIRECT always last
- Auto-select best node for manually tested Selector / URLTest groups
- Refresh tray menu selection state after auto switch
- Avoid tray icon flicker by removing forced destroy/rebuild behavior

## Files changed
- `lib/common/tray.dart`
- `lib/manager/tray_manager.dart`
- `lib/providers/proxy_delay_provider.dart`
- generated freezed / g.dart files

## Notes
This focuses on macOS tray behavior and keeps the current cross-platform tray_manager limitations unchanged.