### PR TITLE
修复：配置变更后内核强制重启导致新内核未加载配置的问题

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -37,8 +37,10 @@ class AppController {
 
   Timer? _wakelockSyncTimer;
   Completer<void>? _restartLock;
+  Completer<void>? _changeProfileLock;
   Completer<void>? _exitLock;
   int _backgroundLoadVersion = 0;
+  bool _hasPendingProfileChange = false;
 
   int _updateGroupsRetryCount = 0;
   bool _isUpdatingGroups = false;
@@ -541,13 +543,36 @@ class AppController {
     addCheckIpNumDebounce();
   }
 
-  Future<void> handleChangeProfile() async {
+  Future<void> _handleChangeProfile() async {
     _ref.read(delayDataSourceProvider.notifier).value = {};
-    await applyProfile(silence: true);
     await restartCore();
+    await applyProfile(silence: true);
     _ref.read(logsProvider.notifier).value = FixedList(maxLength);
     _ref.read(requestsProvider.notifier).value = FixedList(maxLength);
     globalState.computeHeightMapCache = {};
+  }
+
+  Future<void> handleChangeProfile() async {
+    if (_changeProfileLock != null) {
+      _hasPendingProfileChange = true;
+      return _changeProfileLock!.future;
+    }
+
+    final lock = Completer<void>();
+    _changeProfileLock = lock;
+
+    try {
+      do {
+        _hasPendingProfileChange = false;
+        await _handleChangeProfile();
+      } while (_hasPendingProfileChange);
+      lock.complete();
+    } catch (e, stackTrace) {
+      lock.completeError(e, stackTrace);
+      rethrow;
+    } finally {
+      _changeProfileLock = null;
+    }
   }
 
   void updateBrightness() {


### PR DESCRIPTION
## 变更说明

- 调整配置变更流程，从先应用配置再重启内核，改为先重启内核再应用最新配置。
- 为 `handleChangeProfile()` 增加串行保护，避免 profile、脚本、DNS 等配置变化连续触发时并发执行重启和配置应用。
- 确保 `updateGroups()` 在配置已应用到当前内核后再读取代理组，减少代理组为空的异常日志。

## 问题原因

之前配置变更时会先执行 `applyProfile()`，将配置应用到当前内核，然后立刻执行 `restartCore()`。这会导致刚应用过配置的旧内核被重启，新内核未必已经加载最新配置，后续内核读取代理组时可能得到空结果，导致代理批量不可用（表现为所有节点超时）

同时，`needSetupProvider` 可能短时间连续变化，导致多次 `handleChangeProfile()` 流程交错执行，放大了这个时序问题。
