### PR TITLE
修复: [Linux]  阻止运行其他实例导致的APP异常重新初始化

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -60,6 +60,12 @@ G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
+
+  if (main_window != nullptr) {
+    gtk_window_present(main_window);
+    return;
+  }
+
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 


### PR DESCRIPTION
When a second bettbox instance starts, GtkApplication's D-Bus infrastructure sends an 'activate' signal to the first instance, which previously created a second GtkWindow + Flutter engine in the same process. This caused main() to re-execute in a new Dart isolate, spawning a duplicate core process with its own socket file.

Add a guard to check if main_window already exists and just present the existing window instead of creating a new one.

This closes #267 