### PR TITLE
fix(widgets): 防止 grid.dart crossAxisExtent 为负导致 BoxConstraints 断言崩溃

### DIFF
--- a/lib/widgets/grid.dart
+++ b/lib/widgets/grid.dart
@@ -227,7 +227,7 @@ class RenderGrid extends RenderBox
         childParentData,
         crossAxisCount,
       );
-      final crossAxisExtent = stride * crossAxisCellCount - crossAxisSpacing;
+      final crossAxisExtent = math.max(0.0, stride * crossAxisCellCount - crossAxisSpacing);
       final shouldFitContent = childParentData.mainAxisCellCount == null;
 
       double mainAxisExtent = 0;


### PR DESCRIPTION
当可用宽度小于 (crossAxisCount - 1) * crossAxisSpacing 时， stride * crossAxisCellCount - crossAxisSpacing 会计算出负值， 传给 BoxConstraints.tightFor(width: -8.0) 触发断言失败，进而引发 semantics 树递归爆栈导致 app 崩溃。

添加 math.max(0.0, ...) 防护。

修复 https://t.me/appshub_chat/174594