### PR TITLE
Fix minor bugs

### DIFF
--- a/lib/clash/service.dart
+++ b/lib/clash/service.dart
@@ -177,13 +177,17 @@ class ClashService extends ClashHandlerInterface {
           await _waitForCoreReady();
           isStarting = false;
           if (globalState.config.appSetting.enableHighPriority) {
-            unawaited(helperClient.setProcessPriority(
-              '${AppIdentity.coreExecutableName}.exe',
-              true,
-            ).catchError((e) {
-              commonPrint.log('Failed to set core process priority: $e');
-              return false;
-            }));
+            unawaited(
+              helperClient
+                  .setProcessPriority(
+                    '${AppIdentity.coreExecutableName}.exe',
+                    true,
+                  )
+                  .catchError((e) {
+                    commonPrint.log('Failed to set core process priority: $e');
+                    return false;
+                  }),
+            );
           }
           return;
         }
@@ -203,14 +207,15 @@ class ClashService extends ClashHandlerInterface {
     });
     await _waitForCoreReady();
     isStarting = false;
-    if (globalState.config.appSetting.enableHighPriority) {
-      unawaited(helperClient.setProcessPriority(
-        '${AppIdentity.coreExecutableName}.exe',
-        true,
-      ).catchError((e) {
-        commonPrint.log('Failed to set core process priority: $e');
-        return false;
-      }));
+    if (system.isWindows && globalState.config.appSetting.enableHighPriority) {
+      unawaited(
+        helperClient
+            .setProcessPriority('${AppIdentity.coreExecutableName}.exe', true)
+            .catchError((e) {
+              commonPrint.log('Failed to set core process priority: $e');
+              return false;
+            }),
+      );
     }
   }
 

--- a/lib/clash/service.dart
+++ b/lib/clash/service.dart
@@ -238,7 +238,7 @@ class ClashService extends ClashHandlerInterface {
 
   @override
   sendMessage(String message) async {
-    if (_isDestroying || globalState.isExiting) {
+    if (_isDestroying || globalState.isExiting || isStarting) {
       return;
     }
     final socket = await socketCompleter.future;
@@ -246,8 +246,18 @@ class ClashService extends ClashHandlerInterface {
       final frame = FrameCodec.encode(message);
       socket.add(frame);
     } on SocketException catch (e) {
-      if (_isDestroying || globalState.isExiting) {
-        commonPrint.log('Ignore socket error during shutdown: $e');
+      if (_isDestroying || globalState.isExiting || isStarting) {
+        commonPrint.log(
+          'Ignored message send on closed socket during transition: $e',
+        );
+        return;
+      }
+      rethrow;
+    } on StateError catch (e) {
+      if (_isDestroying || globalState.isExiting || isStarting) {
+        commonPrint.log(
+          'Ignored message send on closed socket during transition: $e',
+        );
         return;
       }
       rethrow;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,8 +9,8 @@ import 'package:bett_box/plugins/tile.dart';
 import 'package:bett_box/plugins/vpn.dart';
 import 'package:bett_box/state.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'application.dart';
 import 'clash/core.dart';
@@ -48,8 +48,8 @@ Future<void> main(List<String> args) async {
   PaintingBinding.instance.imageCache.maximumSizeBytes = 50 * 1024 * 1024;
 
   final version = await system.version;
-  await clashCore.preload();
   await globalState.initApp(version);
+  await clashCore.preload();
 
   try {
     await uiManager.initializeUI();

--- a/lib/widgets/grid.dart
+++ b/lib/widgets/grid.dart
@@ -1,7 +1,8 @@
+import 'dart:math' as math;
+
 import 'package:bett_box/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'dart:math' as math;
 
 typedef WrapBuilder = Widget Function(Widget child);
 
@@ -227,7 +228,10 @@ class RenderGrid extends RenderBox
         childParentData,
         crossAxisCount,
       );
-      final crossAxisExtent = stride * crossAxisCellCount - crossAxisSpacing;
+      final crossAxisExtent = math.max(
+        0.0,
+        stride * crossAxisCellCount - crossAxisSpacing,
+      );
       final shouldFitContent = childParentData.mainAxisCellCount == null;
 
       double mainAxisExtent = 0;
@@ -242,9 +246,10 @@ class RenderGrid extends RenderBox
             : child.size.width;
       } else {
         final mainAxisCellCount = childParentData.mainAxisCellCount ?? 1;
-        mainAxisExtent =
-            (this.mainAxisExtent ?? stride) * mainAxisCellCount -
-            mainAxisSpacing;
+        mainAxisExtent = math.max(
+          0.0,
+          (this.mainAxisExtent ?? stride) * mainAxisCellCount - mainAxisSpacing,
+        );
         childParentData.realMainAxisExtent = mainAxisExtent;
         final childSize = mainAxis == Axis.vertical
             ? Size(crossAxisExtent, mainAxisExtent)


### PR DESCRIPTION
Current code can't work properly on my pc. So I have to do somthing to make it work :)
My env: Arch Linux x86_64 + KDE
It's strange that Fix 3 doesn't seem to be platform related, which means the problem should also exists on windows and android. (Did I miss anything?)
It works in my env, but I also wonder if there's better solutions.

## Fix 1:

### Error:

Exception has occurred.

FlutterError (BoxConstraints has a negative minimum width.
These invalid constraints were provided to RenderConstrainedBox's layout() function by the following function, which probably computed the invalid constraints in question:
RenderGrid._layoutChild (package:bett_box/widgets/grid.dart:208:11)
The offending constraints were:
BoxConstraints(w=-8.0, 0.0<=h<=Infinity; NOT NORMALIZED))

### Cause:

in lib/widgets/grid.dart line 230:
```dart
final crossAxisExtent = stride * crossAxisCellCount - crossAxisSpacing;
```
stride = 2.0, spacing = 16.0, count = 8
therefore crossAxisExtent = 2.0 * 4 - 16.0 = 8.0 - 16.0 = -8.0
according to line 221:
```dart
final stride = (crossAxisExtent + crossAxisSpacing) / crossAxisCount;
```
crossAxisExtent of parent is 0.0, which may be the root cause.

### Solution:

to prevent negative value:
```dart
final crossAxisExtent = math.max(0.0, stride * crossAxisCellCount - crossAxisSpacing);
```
also did the same for mainAxisExtent just in case.


## Fix 2:

add missing OS constraints when trying to enable high priority since commit https://github.com/appshubcc/Bettbox/commit/43aa9cffeb5073a1fe518d684f01cebe3ee9d31c

```dart
if (globalState.config.appSetting.enableHighPriority)
```
### Solution:

```dart
if (system.isWindows && globalState.config.appSetting.enableHighPriority)
```

## Fix 3:

LateError (LateInitializtionError: field 'config' has not been initialized.) also since commit https://github.com/appshubcc/Bettbox/commit/43aa9cffeb5073a1fe518d684f01cebe3ee9d31c

### Cause:

ClashService._doRestart() try to access GlobalState.config, but GlobalState.config is not initialized when ClashService._doRestart() is called.

### Solution:

switch sequence of
```dart
  await clashCore.preload(); // this is where ClashService._doRestart() is called
  await globalState.initApp(version); // this is where GlobalState.config initialized
```
to
```dart
  await globalState.initApp(version);
  await clashCore.preload();
```
so that GlobalState.config is initialized before accessed.

## Fix 4:

When switching profile:
StateError (Bad state: StreamSink is closed)
in lib/clash/service.dart, ClashService.sendMessage:
```dart
socket.add(frame);
```
StateError isn't caught.

### Cause:

Profile Switch Triggered
          │
          ├──> 1. reStart() runs -> _destroySocket() calls `socket.close()`
          │
          └──> 2. App tries to sync state -> calls sendMessage(message)
                    │
                    ├──> 3. sendMessage checks `_isDestroying` (which is FALSE during restart)
                    ├──> 4. sendMessage grabs the OLD socket right as it's being closed
                    └──> 5. socket.add(frame) fails -> StateError (Sink is closed)

### Solution:

1. Add isStarting check in sendMessage
2. Catch StateError in sendMessage