### PR TITLE
fix: handle WebDAV cross-origin download redirects

### DIFF
--- a/lib/common/dav_client.dart
+++ b/lib/common/dav_client.dart
@@ -3,16 +3,30 @@ import 'dart:typed_data';
 
 import 'package:bett_box/common/common.dart';
 import 'package:bett_box/models/models.dart';
+import 'package:dio/dio.dart';
 import 'package:webdav_client/webdav_client.dart';
 
 class DAVClient {
   late Client client;
   Completer<bool> pingCompleter = Completer();
   late String fileName;
+  late final Uri _serverUri;
 
   DAVClient(DAV dav) {
     client = newClient(dav.uri, user: dav.user, password: dav.password);
     fileName = dav.fileName;
+    _serverUri = Uri.parse(dav.uri);
+    client.c.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          if (!_hasSameOrigin(options.uri, _serverUri)) {
+            options.headers.remove('authorization');
+            options.headers.remove('Authorization');
+          }
+          handler.next(options);
+        },
+      ),
+    );
     client.setHeaders({'accept-charset': 'utf-8', 'Content-Type': 'text/xml'});
     // 增加超时时间以适应慢速网络
     client.setConnectTimeout(15000); // 15秒连接超时
@@ -70,11 +84,17 @@ class DAVClient {
         commonPrint.log('WebDAV mkdir warning: $e');
       }
 
-      // 下载文件
+      // 跨域重定向的 Authorization 会由请求拦截器移除。
       final data = await client.read(backupFile);
       commonPrint.log('WebDAV recovery successful: ${data.length} bytes');
       return data;
     }, operationName: 'recovery');
+  }
+
+  bool _hasSameOrigin(Uri left, Uri right) {
+    return left.scheme.toLowerCase() == right.scheme.toLowerCase() &&
+        left.host.toLowerCase() == right.host.toLowerCase() &&
+        left.port == right.port;
   }
 
   /// 重试机制：最多重试3次，指数退避

--- a/test/common/dav_client_test.dart
+++ b/test/common/dav_client_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bett_box/common/dav_client.dart';
+import 'package:bett_box/models/models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('removes WebDAV authorization after a cross-origin redirect', () async {
+    final downloadedBytes = utf8.encode('backup-data');
+    final storageServer = await HttpServer.bind(
+      InternetAddress.loopbackIPv4,
+      0,
+    );
+    final webDavServer = await HttpServer.bind(
+      InternetAddress.loopbackIPv4,
+      0,
+    );
+    var storageReceivedAuthorization = false;
+
+    final storageSubscription = storageServer.listen((request) async {
+      storageReceivedAuthorization =
+          request.headers.value(HttpHeaders.authorizationHeader) != null;
+      if (storageReceivedAuthorization) {
+        request.response.statusCode = HttpStatus.unauthorized;
+      } else {
+        request.response.statusCode = HttpStatus.ok;
+        request.response.add(downloadedBytes);
+      }
+      await request.response.close();
+    });
+
+    final webDavSubscription = webDavServer.listen((request) async {
+      final authorization = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      if (authorization == null) {
+        request.response.statusCode = HttpStatus.unauthorized;
+        request.response.headers.set(
+          HttpHeaders.wwwAuthenticateHeader,
+          'Basic realm="test"',
+        );
+      } else if (request.method == 'OPTIONS') {
+        request.response.statusCode = HttpStatus.ok;
+      } else if (request.method == 'MKCOL') {
+        request.response.statusCode = HttpStatus.methodNotAllowed;
+      } else if (request.method == 'GET') {
+        request.response.statusCode = HttpStatus.found;
+        request.response.headers.set(
+          HttpHeaders.locationHeader,
+          'http://${storageServer.address.host}:${storageServer.port}/backup.zip',
+        );
+      } else {
+        request.response.statusCode = HttpStatus.notFound;
+      }
+      await request.response.close();
+    });
+
+    try {
+      final client = DAVClient(
+        DAV(
+          uri: 'http://${webDavServer.address.host}:${webDavServer.port}',
+          user: 'user',
+          password: 'password',
+        ),
+      );
+
+      expect(await client.pingCompleter.future, isTrue);
+      expect(await client.recovery(), downloadedBytes);
+      expect(storageReceivedAuthorization, isFalse);
+    } finally {
+      await webDavServer.close(force: true);
+      await storageServer.close(force: true);
+      await webDavSubscription.cancel();
+      await storageSubscription.cancel();
+    }
+  });
+}


### PR DESCRIPTION
问题：Openlist等与对象存储挂载的webdav不能正确使用
<img width="1314" height="1012" alt="image" src="https://github.com/user-attachments/assets/51abcea9-ade7-4521-bfa4-2fd036dad3bb" />


本次修改解决了 WebDAV 上传正常、下载因跨域重定向返回 Unauthorized 的问题。
- 在 WebDAV 客户端增加 Dio 请求拦截器。
- 同源请求继续携带 Authorization，保证 Basic/Digest 认证正常。
- 下载重定向到对象存储等不同域名时，自动移除 WebDAV 认证头，避免目标服务器返回 401/403。
- 保持原有上传、ping、超时及重试逻辑不变。
- 新增本地双服务器测试，模拟 WebDAV 重定向到对象存储并验证认证头不会泄露到其他 origin。
- 公网测试端点验证下载成功：HTTP 200。

与该问题关联 #312
 