### PR TITLE
feat: support DUFS webdav

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dkeystore.jks.type=PKCS12
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true

--- a/lib/common/dav_client.dart
+++ b/lib/common/dav_client.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:bett_box/common/common.dart';
 import 'package:bett_box/models/models.dart';
+import 'package:dio/dio.dart';
 import 'package:webdav_client/webdav_client.dart';
 
 class DAVClient {
@@ -13,6 +14,21 @@ class DAVClient {
   DAVClient(DAV dav) {
     client = newClient(dav.uri, user: dav.user, password: dav.password);
     fileName = dav.fileName;
+    client.c.interceptors.add(
+      InterceptorsWrapper(
+        onResponse: (response, handler) {
+          final challenges = response.headers['www-authenticate'];
+          if (response.statusCode == 401 &&
+              challenges != null &&
+              challenges.length > 1) {
+            // webdav_client reads this header through Headers.value(), which
+            // throws when servers such as DUFS advertise Digest and Basic.
+            response.headers.set('www-authenticate', challenges.join(', '));
+          }
+          handler.next(response);
+        },
+      ),
+    );
     client.setHeaders({'accept-charset': 'utf-8', 'Content-Type': 'text/xml'});
     // 增加超时时间以适应慢速网络
     client.setConnectTimeout(15000); // 15秒连接超时

--- a/test/common/dav_client_test.dart
+++ b/test/common/dav_client_test.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bett_box/common/dav_client.dart';
+import 'package:bett_box/models/models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('supports servers with multiple WWW-Authenticate headers', () async {
+    final backupBytes = utf8.encode('backup-data');
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    var storedBytes = <int>[];
+
+    final subscription = server.listen((request) async {
+      final authorization = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      if (authorization == null) {
+        request.response.statusCode = HttpStatus.unauthorized;
+        request.response.headers.add(
+          HttpHeaders.wwwAuthenticateHeader,
+          'Digest realm="DUFS", nonce="test-nonce", qop="auth"',
+          preserveHeaderCase: true,
+        );
+        request.response.headers.add(
+          HttpHeaders.wwwAuthenticateHeader,
+          'Basic realm="DUFS"',
+          preserveHeaderCase: true,
+        );
+      } else if (request.method == 'OPTIONS') {
+        request.response.statusCode = HttpStatus.ok;
+      } else if (request.method == 'MKCOL') {
+        request.response.statusCode = HttpStatus.created;
+      } else if (request.method == 'PUT') {
+        storedBytes = await request.fold<List<int>>(
+          <int>[],
+          (bytes, chunk) => bytes..addAll(chunk),
+        );
+        request.response.statusCode = HttpStatus.created;
+      } else if (request.method == 'GET') {
+        request.response.statusCode = HttpStatus.ok;
+        request.response.add(storedBytes);
+      } else {
+        request.response.statusCode = HttpStatus.notFound;
+      }
+      await request.response.close();
+    });
+
+    try {
+      final client = DAVClient(
+        DAV(
+          uri: 'http://${server.address.host}:${server.port}',
+          user: 'test',
+          password: 'password',
+        ),
+      );
+
+      expect(await client.pingCompleter.future, isTrue);
+      expect(await client.backup(backupBytes), isTrue);
+      expect(storedBytes, backupBytes);
+      expect(await client.recovery(), backupBytes);
+    } finally {
+      await server.close(force: true);
+      await subscription.cancel();
+    }
+  });
+}


### PR DESCRIPTION
修改点：
- 根因是 DUFS 同时返回 Digest 和 Basic 两条 WWW-Authenticate，webdav_client 1.2.2 使用单值接口读取时直接抛异常。
- 在响应拦截器中合并多条认证挑战，使依赖能够继续进行 Digest 认证。
- 新增回归测试，覆盖双认证头、连接检测、创建目录、上传及恢复流程。
- 实际服务器已验证 Digest、MKCOL、PUT、GET、DELETE 均正常。

根据 @xream 提供的公网服务 测试日志文件如下， 无法进行上传
```
Log(logLevel: LogLevel.info, payload: [APP] WebDAV ping successful, dateTime: 2026-07-27 21:35:04)
Log(logLevel: LogLevel.info, payload: [APP] updateGroups error: getProxiesGroups returned empty after inner retries, dateTime: 2026-07-27 21:35:14)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV ping successful, dateTime: 2026-07-27 21:35:22)
Log(logLevel: LogLevel.info, payload: [APP] updateGroups error: getProxiesGroups returned empty after inner retries, dateTime: 2026-07-27 21:35:22)
Log(logLevel: LogLevel.info, payload: [APP] Starting backup: 0 profiles, current: null, dateTime: 2026-07-27 21:35:24)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV backup: uploading 2731 bytes to /Bettbox/backup.zip, dateTime: 2026-07-27 21:35:24)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV mkdir warning (may already exist): Exception: "www-authenticate" header has more than one value, please use Headers[name], dateTime: 2026-07-27 21:35:24)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV backup attempt 1 failed: Exception: "www-authenticate" header has more than one value, please use Headers[name], retrying in 2s..., dateTime: 2026-07-27 21:35:24)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV backup: uploading 2731 bytes to /Bettbox/backup.zip, dateTime: 2026-07-27 21:35:26)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV mkdir warning (may already exist): Exception: "www-authenticate" header has more than one value, please use Headers[name], dateTime: 2026-07-27 21:35:27)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV backup attempt 2 failed: Exception: "www-authenticate" header has more than one value, please use Headers[name], retrying in 4s..., dateTime: 2026-07-27 21:35:27)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV backup: uploading 2731 bytes to /Bettbox/backup.zip, dateTime: 2026-07-27 21:35:31)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV mkdir warning (may already exist): Exception: "www-authenticate" header has more than one value, please use Headers[name], dateTime: 2026-07-27 21:35:32)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV backup failed after 3 attempts: Exception: "www-authenticate" header has more than one value, please use Headers[name], dateTime: 2026-07-27 21:35:32)
Log(logLevel: LogLevel.info, payload: [APP] WebDAV backup failed: Exception: "www-authenticate" header has more than one value, please use Headers[name], dateTime: 2026-07-27 21:35:32)
Log(logLevel: LogLevel.info, payload: [APP] updateGroups error: getProxiesGroups returned empty after inner retries, dateTime: 2026-07-27 21:35:47)
Log(logLevel: LogLevel.info, payload: [APP] updateGroups error: getProxiesGroups returned empty after inner retries, dateTime: 2026-07-27 21:36:13)
Log(logLevel: LogLevel.info, payload: [APP] updateGroups error: getProxiesGroups returned empty after inner retries, dateTime: 2026-07-27 21:36:43)
Log(logLevel: LogLevel.info, payload: [APP] updateGroups error: getProxiesGroups returned empty after inner retries, dateTime: 2026-07-27 21:39:38)
```