### PR TITLE
修复：自动设置系统 DNS 与 TUN 状态联动

### DIFF
--- a/lib/application.dart
+++ b/lib/application.dart
@@ -156,6 +156,14 @@ class ApplicationState extends ConsumerState<Application>
             if (!results.contains(ConnectivityResult.vpn)) {
               clashCore.closeConnections();
             }
+            if (system.isMacOS) {
+              // Wait for DHCP and the default route to settle before moving the
+              // managed DNS from the previous network to the new one.
+              await Future.delayed(const Duration(seconds: 1));
+              if (!mounted) return;
+              final dnsState = ref.read(autoSetSystemDnsStateProvider);
+              await macOS?.updateDns(!(dnsState.a && dnsState.b));
+            }
             globalState.appController.updateLocalIp();
             globalState.appController.addCheckIpNumDebounce();
           },

--- a/lib/common/system.dart
+++ b/lib/common/system.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
 
@@ -12,6 +13,7 @@ import 'package:bett_box/state.dart';
 import 'package:bett_box/widgets/input.dart';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart';
+import 'package:synchronized/synchronized.dart';
 
 class System {
   static System? _instance;
@@ -493,8 +495,9 @@ final windows = system.isWindows ? Windows() : null;
 
 class MacOS {
   static MacOS? _instance;
-
-  List<String>? originDns;
+  static const _dnsBackupFileName = 'macos_system_dns_backup.json';
+  static const _hijackDns = '223.5.5.5';
+  final Lock _dnsLock = Lock();
 
   MacOS._internal();
 
@@ -528,48 +531,122 @@ class MacOS {
           (line) => RegExp(r'^\(\d+\).*').hasMatch(line),
           orElse: () => '',
         );
-    final nameParts = serviceNameLine.trim().split(' ');
-    if (nameParts.length < 2) return null;
-    return nameParts[1];
+    final match = RegExp(
+      r'^\(\d+\)\s+(.+)$',
+    ).firstMatch(serviceNameLine.trim());
+    return match?.group(1)?.trim();
   }
 
   Future<List<String>?> get systemDns async {
     final deviceServiceName = await defaultServiceName;
     if (deviceServiceName == null) return null;
-
-    final result = await Process.run('networksetup', [
-      '-getdnsservers',
-      deviceServiceName,
-    ]);
-    final output = result.stdout.toString().trim();
-    originDns = output.startsWith("There aren't any DNS Servers set on")
-        ? []
-        : output.split('\n');
-    return originDns;
+    return _getSystemDns(deviceServiceName);
   }
 
-  Future<void> updateDns(bool restore) async {
+  Future<List<String>?> _getSystemDns(String serviceName) async {
+    final result = await Process.run('networksetup', [
+      '-getdnsservers',
+      serviceName,
+    ]);
+    if (result.exitCode != 0) {
+      commonPrint.log(
+        'Failed to get macOS system DNS: ${result.stderr.toString().trim()}',
+      );
+      return null;
+    }
+    final output = result.stdout.toString().trim();
+    return output.startsWith("There aren't any DNS Servers set on")
+        ? []
+        : output.split('\n');
+  }
+
+  Future<void> updateDns(bool restore) {
+    return _dnsLock.synchronized(() async {
+      if (restore) {
+        await _restoreDns();
+      } else {
+        await _setDns();
+      }
+    });
+  }
+
+  Future<void> _setDns() async {
+    // Restore a previous managed value first so repeated enable operations never
+    // overwrite the real system DNS backup with Bettbox's own hijack DNS.
+    if (!await _restoreDns()) return;
+
     final serviceName = await defaultServiceName;
     if (serviceName == null) return;
 
-    List<String>? nextDns;
-    if (restore) {
-      nextDns = originDns;
-    } else {
-      final currentDns = await systemDns;
-      if (currentDns == null) return;
-      const needAddDns = '223.5.5.5';
-      if (currentDns.contains(needAddDns)) return;
-      nextDns = List.from(currentDns)..add(needAddDns);
-    }
-    if (nextDns == null) return;
+    final currentDns = await _getSystemDns(serviceName);
+    if (currentDns == null || currentDns.contains(_hijackDns)) return;
 
-    await Process.run('networksetup', [
+    final backup = jsonEncode({
+      'serviceName': serviceName,
+      'servers': currentDns,
+    });
+    try {
+      final backupFile = await _dnsBackupFile;
+      await backupFile.parent.create(recursive: true);
+      final temporaryFile = File('${backupFile.path}.tmp');
+      await temporaryFile.writeAsString(backup, flush: true);
+      await temporaryFile.rename(backupFile.path);
+    } catch (e) {
+      commonPrint.log('Failed to persist the original macOS system DNS: $e');
+      return;
+    }
+
+    final result = await Process.run('networksetup', [
       '-setdnsservers',
       serviceName,
-      if (nextDns.isNotEmpty) ...nextDns,
-      if (nextDns.isEmpty) 'Empty',
+      ...currentDns,
+      _hijackDns,
     ]);
+    if (result.exitCode != 0) {
+      commonPrint.log(
+        'Failed to set macOS system DNS: ${result.stderr.toString().trim()}',
+      );
+    }
+  }
+
+  Future<bool> _restoreDns() async {
+    final backupFile = await _dnsBackupFile;
+    if (!await backupFile.exists()) return true;
+
+    try {
+      final rawBackup = await backupFile.readAsString();
+      final backup = jsonDecode(rawBackup) as Map<String, dynamic>;
+      final serviceName = backup['serviceName'] as String?;
+      final servers = (backup['servers'] as List?)
+          ?.whereType<String>()
+          .toList();
+      if (serviceName == null || serviceName.isEmpty || servers == null) {
+        throw const FormatException('Invalid macOS system DNS backup');
+      }
+
+      final result = await Process.run('networksetup', [
+        '-setdnsservers',
+        serviceName,
+        if (servers.isNotEmpty) ...servers,
+        if (servers.isEmpty) 'Empty',
+      ]);
+      if (result.exitCode != 0) {
+        commonPrint.log(
+          'Failed to restore macOS system DNS: '
+          '${result.stderr.toString().trim()}',
+        );
+        return false;
+      }
+      await backupFile.delete();
+      return true;
+    } catch (e) {
+      commonPrint.log('Failed to read macOS system DNS backup: $e');
+      return false;
+    }
+  }
+
+  Future<File> get _dnsBackupFile async {
+    return File(join(await appPath.homeDirPath, _dnsBackupFileName));
   }
 }
 

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -971,9 +971,6 @@ class AppController {
         await prefs?.setBool('is_tun_running', false);
       }
       await savePreferences();
-      if (macOS != null) {
-        await macOS!.updateDns(true);
-      }
       if (proxy != null) {
         await proxy!.stopProxy();
       }
@@ -984,6 +981,13 @@ class AppController {
     } catch (e) {
       commonPrint.log('handleExit error: $e');
     } finally {
+      if (macOS != null) {
+        try {
+          await macOS!.updateDns(true);
+        } catch (e) {
+          commonPrint.log('Failed to restore macOS system DNS on exit: $e');
+        }
+      }
       if (!exitLock.isCompleted) {
         exitLock.complete();
       }
@@ -1251,6 +1255,9 @@ class AppController {
           commonPrint.log('Recovery failed: $e');
         }
       }
+    }
+    if (system.isMacOS && !globalState.isStart) {
+      await macOS?.updateDns(true);
     }
     final hasProfile = _ref.read(currentProfileProvider) != null;
     final shouldStart =

--- a/lib/manager/app_manager.dart
+++ b/lib/manager/app_manager.dart
@@ -73,9 +73,9 @@ class _AppStateManagerState extends ConsumerState<AppStateManager>
         return;
       }
       if (next.a == true && next.b == true) {
-        macOS?.updateDns(false);
+        await macOS?.updateDns(false);
       } else {
-        macOS?.updateDns(true);
+        await macOS?.updateDns(true);
       }
     });
     ref.listenManual(currentBrightnessProvider, (prev, next) {

--- a/lib/views/config/network.dart
+++ b/lib/views/config/network.dart
@@ -159,18 +159,22 @@ class AutoSetSystemDnsItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, ref) {
-    final autoSetSystemDns = ref.watch(
-      networkSettingProvider.select((state) => state.autoSetSystemDns),
-    );
+    final autoSetSystemDnsState = ref.watch(autoSetSystemDnsStateProvider);
+    final canSetSystemDns = autoSetSystemDnsState.a;
+    final autoSetSystemDns = autoSetSystemDnsState.b;
     return ListItem.switchItem(
       title: Text(appLocalizations.autoSetSystemDns),
       delegate: SwitchDelegate(
         value: autoSetSystemDns,
-        onChanged: (bool value) async {
-          ref
-              .read(networkSettingProvider.notifier)
-              .updateState((state) => state.copyWith(autoSetSystemDns: value));
-        },
+        onChanged: canSetSystemDns
+            ? (bool value) async {
+                ref
+                    .read(networkSettingProvider.notifier)
+                    .updateState(
+                      (state) => state.copyWith(autoSetSystemDns: value),
+                    );
+              }
+            : null,
       ),
     );
   }


### PR DESCRIPTION
## 变更说明

- 自动设置系统 DNS 仅在 Bettbox 运行、实际 TUN 已开启且 DNS 偏好开启时可用
- TUN、总开关或 DNS 偏好变化时，统一设置或恢复 macOS 系统 DNS
- 监听网络变化，Wi-Fi 切换并等待 DHCP 稳定后，将 DNS 配置迁移到当前默认网络
- 在 Application Support 中持久备份原始 DNS 和网络服务名，避免异常退出后丢失恢复信息
- 正常退出、系统终止回调和下次异常启动恢复时均尝试还原 DNS
- 修复包含空格的 macOS 网络服务名解析

## 对照说明

Clash Verge Rev 的“自动设置全局路由”对应 Mihomo 的 tun.auto-route，与修改系统 DNS 不是同一个字段；本变更参照的是其 TUN 启停时设置/恢复 macOS 公共 DNS 的实际逻辑，并规避了把备份文件写入签名 App Bundle 的问题。

## 验证

- Dart 3.12.2 格式化检查通过
- git diff --check 通过
- 读取本机默认网络服务与 DNS 验证命令参数：Wi-Fi / 223.5.5.5
- 本机未安装 Flutter SDK，未执行完整 flutter analyze/build；未启动第二个 Bettbox 实例

## 关联 Issue

Closes #319