### PR TITLE
fix(core): backport Mihomo DNS and sniffer fixes

### DIFF
--- a/core/Clash.Meta/component/resolver/relay.go
+++ b/core/Clash.Meta/component/resolver/relay.go
@@ -94,7 +94,21 @@ func relayDnsPacket(ctx context.Context, payload []byte, target []byte, maxSize 
 		r.Truncate(maxSize)
 	}
 	r.Compress = true
-	return r.PackBuffer(target)
+	return packDnsMessage(r, target)
+}
+
+func packDnsMessage(msg *D.Msg, target []byte) ([]byte, error) {
+	data, err := msg.PackBuffer(target)
+	if err != nil {
+		return nil, err
+	}
+	// PackBuffer sizes its scratch space by the uncompressed message length and
+	// may allocate a new slice even when the compressed result fits in target.
+	// TUN DNS hijack callers send target, so copy the packed result back first.
+	if len(data) > 0 && len(data) <= len(target) && &data[0] != &target[0] {
+		data = target[:copy(target, data)]
+	}
+	return data, nil
 }
 
 // RelayDnsPacket will truncate udp message up to SafeDnsPacketSize

--- a/core/Clash.Meta/component/resolver/relay_test.go
+++ b/core/Clash.Meta/component/resolver/relay_test.go
@@ -1,0 +1,50 @@
+package resolver
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	D "github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackDnsMessageCopiesReallocatedBuffer(t *testing.T) {
+	query := new(D.Msg)
+	query.SetQuestion("large.example.", D.TypeA)
+
+	response := new(D.Msg)
+	response.SetReply(query)
+	for i := 0; i < 110; i++ {
+		response.Answer = append(response.Answer, &D.A{
+			Hdr: D.RR_Header{
+				Name:   "large.example.",
+				Rrtype: D.TypeA,
+				Class:  D.ClassINET,
+				Ttl:    60,
+			},
+			A: net.IPv4(192, 0, 2, byte(i+1)),
+		})
+	}
+	response.Compress = true
+
+	target := bytes.Repeat([]byte{0xa5}, SafeDnsPacketSize)
+	reallocated, err := response.PackBuffer(target)
+	require.NoError(t, err)
+	require.NotEmpty(t, reallocated)
+	require.LessOrEqual(t, len(reallocated), len(target))
+	require.False(t, &reallocated[0] == &target[0], "fixture must force PackBuffer to reallocate")
+	for i := range target {
+		target[i] = 0xa5
+	}
+
+	data, err := packDnsMessage(response, target)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+	require.LessOrEqual(t, len(data), len(target))
+	require.True(t, &data[0] == &target[0])
+
+	decoded := new(D.Msg)
+	require.NoError(t, decoded.Unpack(data))
+	require.Len(t, decoded.Answer, len(response.Answer))
+}

--- a/core/Clash.Meta/component/sniffer/dispatcher.go
+++ b/core/Clash.Meta/component/sniffer/dispatcher.go
@@ -2,7 +2,6 @@ package sniffer
 
 import (
 	"errors"
-	"net"
 	"net/netip"
 	"time"
 
@@ -192,13 +191,9 @@ func (sd *Dispatcher) sniffDomain(conn *N.BufferedConn, metadata *C.Metadata) (s
 			_, err := conn.Peek(1)
 			_ = conn.SetReadDeadline(time.Time{})
 			if err != nil {
-				_, ok := err.(*net.OpError)
-				if ok {
-					sd.cacheSniffFailed(metadata)
-					log.Errorln("[Sniffer] [%s] [%s] may not have any sent data, Consider adding skip", metadata.DstIP, s.Protocol())
-					_ = conn.Close()
-				}
-
+				// The caller owns failure accounting and the connection lifetime.
+				// Server-first protocols may legitimately send no initial client data.
+				log.Debugln("[Sniffer] [%s] [%s] the data length not enough, error: %v", metadata.DstIP, s.Protocol(), err)
 				return "", err
 			}
 

--- a/core/Clash.Meta/component/sniffer/dispatcher_test.go
+++ b/core/Clash.Meta/component/sniffer/dispatcher_test.go
@@ -1,0 +1,64 @@
+package sniffer
+
+import (
+	"net"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+
+	N "github.com/metacubex/mihomo/common/net"
+	C "github.com/metacubex/mihomo/constant"
+	CS "github.com/metacubex/mihomo/constant/sniffer"
+	"github.com/stretchr/testify/require"
+)
+
+type noInitialDataSniffer struct{}
+
+func (*noInitialDataSniffer) SupportNetwork() C.NetWork { return C.TCP }
+func (*noInitialDataSniffer) SniffData([]byte) (string, error) {
+	return "", ErrNoClue
+}
+func (*noInitialDataSniffer) Protocol() string        { return "test" }
+func (*noInitialDataSniffer) SupportPort(uint16) bool { return true }
+
+type closeTrackingConn struct {
+	net.Conn
+	closed atomic.Bool
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.closed.Store(true)
+	return c.Conn.Close()
+}
+
+func TestInitialReadFailureKeepsConnectionOpen(t *testing.T) {
+	dispatcher, err := NewDispatcher(&Config{
+		Enable:      true,
+		ParsePureIp: true,
+	})
+	require.NoError(t, err)
+	dispatcher.sniffers = map[CS.Sniffer]SnifferConfig{
+		&noInitialDataSniffer{}: {},
+	}
+
+	client, server := net.Pipe()
+	tracked := &closeTrackingConn{Conn: client}
+	t.Cleanup(func() {
+		_ = tracked.Close()
+		_ = server.Close()
+	})
+
+	metadata := &C.Metadata{
+		NetWork: C.TCP,
+		DstIP:   netip.MustParseAddr("192.0.2.1"),
+		DstPort: 80,
+	}
+
+	sniffed := dispatcher.TCPSniff(N.NewBufferedConn(tracked), metadata)
+
+	require.False(t, sniffed)
+	require.False(t, tracked.closed.Load())
+	failures, cached := dispatcher.skipList.Get(metadata.AddrPort())
+	require.True(t, cached)
+	require.Equal(t, uint8(1), failures)
+}


### PR DESCRIPTION
## Summary

Backport two focused fixes that landed in Mihomo Alpha after the 1.19.29 snapshot currently vendored by Bettbox:

- MetaCubeX/mihomo@`fb002210`: copy compressed DNS data back into the caller buffer when `PackBuffer` reallocates, preventing TUN DNS hijack from sending zero-filled or stale packets;
- MetaCubeX/mihomo@`63f15f2d`: keep a TCP connection open when the initial sniff read times out, and leave failure accounting/lifetime ownership to the caller.

No unrelated Mihomo Alpha changes are included.

## Why

Bettbox currently vendors Mihomo 1.19.29, which is still the latest stable release. Both fixes were merged after that release and match two failure shapes observed in #330: DNS-path failures and connection failures that are not limited to DNS.

This PR does **not** claim that these two bugs explain every reported all-node timeout. It only backports narrowly scoped upstream fixes with regression coverage while the broader intermittent data-plane issue is investigated.

## Tests

Executed with Go 1.25.12 under a 2 GiB memory limit:

```text
TestPackDnsMessageCopiesReallocatedBuffer             PASS
TestInitialReadFailureKeepsConnectionOpen             PASS
go test ./component/resolver ./component/sniffer      PASS
```

The resolver fixture verifies that `PackBuffer` really reallocates, the packed response is copied back to the original target buffer, and all 110 DNS answers remain decodable. The sniffer fixture verifies that an initial read timeout does not close the connection and is counted once.

Related: #330
