### PR TITLE
fix: make Core restart failures explicit

### DIFF
--- a/lib/clash/core_startup.dart
+++ b/lib/clash/core_startup.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+class CoreReadyTimeoutException implements Exception {
+  final Duration timeout;
+
+  const CoreReadyTimeoutException(this.timeout);
+
+  @override
+  String toString() =>
+      'Core IPC did not become ready within ${timeout.inSeconds}s';
+}
+
+Future<T> waitForCoreReady<T>(
+  Future<T> ready, {
+  Duration timeout = const Duration(seconds: 5),
+}) async {
+  try {
+    return await ready.timeout(timeout);
+  } on TimeoutException {
+    throw CoreReadyTimeoutException(timeout);
+  }
+}
+
+class CoreStartGuard {
+  bool _isRunning = false;
+
+  bool get isRunning => _isRunning;
+
+  Future<T> run<T>(Future<T> Function() operation) async {
+    if (_isRunning) {
+      throw StateError('Core startup is already in progress');
+    }
+    _isRunning = true;
+    try {
+      return await operation();
+    } finally {
+      _isRunning = false;
+    }
+  }
+}

--- a/lib/clash/service.dart
+++ b/lib/clash/service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:bett_box/clash/core_startup.dart';
 import 'package:bett_box/clash/interface.dart';
 import 'package:bett_box/common/common.dart';
 import 'package:bett_box/enum/enum.dart';
@@ -20,12 +21,14 @@ class ClashService extends ClashHandlerInterface {
 
   Completer<Socket> socketCompleter = Completer();
 
-  bool isStarting = false;
+  final CoreStartGuard _startGuard = CoreStartGuard();
+  bool get isStarting => _startGuard.isRunning;
   bool _isDestroying = false;
 
   Process? process;
 
   Completer<void>? _restartCompleter;
+  late final Future<void> _initialStartup;
 
   TransportType _transportType = TransportType.unixSocket;
   String? _socketPath;
@@ -37,7 +40,7 @@ class ClashService extends ClashHandlerInterface {
   }
 
   ClashService._internal() {
-    _initTransport();
+    _initialStartup = _initTransport();
   }
 
   Future<void> _initTransport() async {
@@ -53,8 +56,8 @@ class ClashService extends ClashHandlerInterface {
       commonPrint.log('Using TCP Socket on port: $_tcpPort');
     }
 
-    _initServer();
-    reStart();
+    unawaited(_initServer());
+    await reStart();
   }
 
   Future<void> _initServer() async {
@@ -99,6 +102,9 @@ class ClashService extends ClashHandlerInterface {
       (error, stack) {
         if (_isDestroying || globalState.isExiting) return;
         commonPrint.log(error.toString());
+        if (!serverCompleter.isCompleted) {
+          serverCompleter.completeError(error, stack);
+        }
         if (error is SocketException &&
             !_isDestroying &&
             !globalState.isExiting) {
@@ -132,98 +138,126 @@ class ClashService extends ClashHandlerInterface {
     }
   }
 
-  Future<void> _doRestart() async {
-    isStarting = true;
-    _isDestroying = false;
+  Future<void> _doRestart() {
+    return _startGuard.run(() async {
+      _isDestroying = false;
+      try {
+        await _destroySocket();
 
-    await _destroySocket();
+        process?.kill();
+        if (process != null) {
+          await process!.exitCode.timeout(
+            const Duration(seconds: 2),
+            onTimeout: () {
+              process?.kill(ProcessSignal.sigkill);
+              return -1;
+            },
+          );
+        }
+        process = null;
 
-    process?.kill();
-    if (process != null) {
-      await process!.exitCode.timeout(
-        const Duration(seconds: 2),
-        onTimeout: () {
-          process?.kill(ProcessSignal.sigkill);
-          return -1;
-        },
-      );
-    }
-    process = null;
+        socketCompleter = Completer();
 
-    socketCompleter = Completer();
+        final serverSocket = await serverCompleter.future;
 
-    final serverSocket = await serverCompleter.future;
+        final String arg;
+        if (_transportType == TransportType.unixSocket) {
+          arg = _socketPath!;
+        } else {
+          arg = '${serverSocket.port}';
+        }
 
-    final String arg;
-    if (_transportType == TransportType.unixSocket) {
-      arg = _socketPath!;
-    } else {
-      arg = '${serverSocket.port}';
-    }
+        final homeDirPath = await appPath.homeDirPath;
+        final environment = Map<String, String>.from(Platform.environment);
+        environment['SAFE_PATHS'] = homeDirPath;
 
-    final homeDirPath = await appPath.homeDirPath;
-    final environment = Map<String, String>.from(Platform.environment);
-    environment['SAFE_PATHS'] = homeDirPath;
-
-    if (system.isWindows) {
-      final serviceOk = await windows?.registerService() ?? false;
-      if (serviceOk) {
-        final started = await helperClient.startCore(
-          corePath: appPath.corePath,
-          arg: arg,
-          homeDir: homeDirPath,
-        );
-        if (started) {
-          await _waitForCoreReady();
-          isStarting = false;
-          if (system.isWindows && globalState.config.appSetting.enableHighPriority) {
-            unawaited(
-              helperClient
-                  .setProcessPriority(
-                    '${AppIdentity.coreExecutableName}.exe',
-                    true,
-                  )
-                  .catchError((e) {
-                    commonPrint.log('Failed to set core process priority: $e');
-                    return false;
-                  }),
+        if (system.isWindows) {
+          final serviceOk = await windows?.registerService() ?? false;
+          if (serviceOk) {
+            final started = await helperClient.startCore(
+              corePath: appPath.corePath,
+              arg: arg,
+              homeDir: homeDirPath,
+            );
+            if (started) {
+              await _waitForCoreReady();
+              _setHighPriority();
+              return;
+            }
+            commonPrint.log(
+              'Helper start core failed, falling back to normal mode',
             );
           }
-          return;
         }
-        commonPrint.log(
-          'Helper start core failed, falling back to normal mode',
-        );
-      }
-    }
 
-    process = await Process.start(appPath.corePath, [
-      arg,
-    ], environment: environment);
-    process?.stdout.listen((_) {});
-    process?.stderr.listen((e) {
-      final error = utf8.decode(e);
-      if (error.isNotEmpty) commonPrint.log(error);
+        process = await Process.start(appPath.corePath, [
+          arg,
+        ], environment: environment);
+        process?.stdout.listen((_) {});
+        process?.stderr.listen((e) {
+          final error = utf8.decode(e);
+          if (error.isNotEmpty) commonPrint.log(error);
+        });
+        await _waitForCoreReady();
+        _setHighPriority();
+      } catch (error, stackTrace) {
+        commonPrint.log('Core restart failed: $error');
+        try {
+          await _cleanupFailedCoreStart();
+        } catch (cleanupError) {
+          commonPrint.log(
+            'Failed to clean up Core after startup error: $cleanupError',
+          );
+        }
+        Error.throwWithStackTrace(error, stackTrace);
+      }
     });
-    await _waitForCoreReady();
-    isStarting = false;
-    if (system.isWindows && globalState.config.appSetting.enableHighPriority) {
-      unawaited(
-        helperClient
-            .setProcessPriority('${AppIdentity.coreExecutableName}.exe', true)
-            .catchError((e) {
-              commonPrint.log('Failed to set core process priority: $e');
-              return false;
-            }),
-      );
-    }
   }
 
   Future<void> _waitForCoreReady() async {
+    await waitForCoreReady(socketCompleter.future);
+  }
+
+  void _setHighPriority() {
+    if (!system.isWindows ||
+        !globalState.config.appSetting.enableHighPriority) {
+      return;
+    }
+    unawaited(
+      helperClient
+          .setProcessPriority('${AppIdentity.coreExecutableName}.exe', true)
+          .catchError((e) {
+            commonPrint.log('Failed to set core process priority: $e');
+            return false;
+          }),
+    );
+  }
+
+  Future<void> _cleanupFailedCoreStart() async {
+    _isDestroying = true;
     try {
-      await socketCompleter.future.timeout(const Duration(seconds: 5));
-    } catch (_) {
-      commonPrint.log('Core ready timeout after 5s');
+      if (system.isWindows) {
+        try {
+          await helperClient.stopCore().timeout(const Duration(seconds: 5));
+        } catch (error) {
+          commonPrint.log('Failed to stop Core after startup error: $error');
+        }
+      }
+      await _destroySocket();
+      process?.kill();
+      if (process != null) {
+        await process!.exitCode.timeout(
+          const Duration(seconds: 2),
+          onTimeout: () {
+            process?.kill(ProcessSignal.sigkill);
+            return -1;
+          },
+        );
+      }
+      process = null;
+      socketCompleter = Completer();
+    } finally {
+      _isDestroying = false;
     }
   }
 
@@ -293,6 +327,9 @@ class ClashService extends ClashHandlerInterface {
     return true;
   }
 
+  /// Checks IPC/control-plane health only.
+  ///
+  /// A true result does not prove that TUN or mixed-port traffic can pass.
   Future<bool> checkCoreHealth({
     Duration timeout = const Duration(seconds: 2),
   }) async {
@@ -311,7 +348,7 @@ class ClashService extends ClashHandlerInterface {
 
   @override
   Future<bool> preload() async {
-    await serverCompleter.future;
+    await _initialStartup;
     return true;
   }
 }

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -114,6 +114,9 @@ class AppController {
       _ref.read(isRestartingCoreProvider.notifier).state = true;
       try {
         await _restartCore();
+      } catch (err) {
+        _reportCoreRestartFailure(err);
+        rethrow;
       } finally {
         _ref.read(isRestartingCoreProvider.notifier).state = false;
       }
@@ -381,7 +384,8 @@ class AppController {
 
   Future<bool> _shouldUpdateDashboardTick() async {
     final lifecycleState = WidgetsBinding.instance.lifecycleState;
-    final isPinned = system.isDesktop &&
+    final isPinned =
+        system.isDesktop &&
         _ref.read(windowSettingProvider.select((s) => s.isPinned));
     if (!isPinned && lifecycleState != AppLifecycleState.resumed) return false;
 
@@ -652,9 +656,16 @@ class AppController {
   Future<void> handleChangeProfile({bool hardRestart = false}) {
     return _coreLifecycleLock.synchronized(() async {
       if (hardRestart) {
+        _ref.read(delayDataSourceProvider.notifier).value = {};
+        _ref.read(groupsProvider.notifier).value = [];
+        _ref.read(providersProvider.notifier).value = [];
+        globalState.computeHeightMapCache = {};
         _ref.read(isRestartingCoreProvider.notifier).state = true;
         try {
           await _restartCore();
+        } catch (err) {
+          _reportCoreRestartFailure(err);
+          rethrow;
         } finally {
           _ref.read(isRestartingCoreProvider.notifier).state = false;
         }
@@ -675,11 +686,15 @@ class AppController {
           globalState.showNotifier(err.toString());
         }
       }
-      _ref.read(logsProvider.notifier).value = FixedList(maxLength);
-      _ref.read(requestsProvider.notifier).value = FixedList(maxLength);
       globalState.computeHeightMapCache = {};
       addCheckIpNumDebounce();
     });
+  }
+
+  void _reportCoreRestartFailure(Object error) {
+    final message = error.formatError;
+    commonPrint.log('[Core] Restart failed: $message');
+    globalState.showNotifier('${appLocalizations.restartCoreTitle}: $message');
   }
 
   void updateBrightness() {
@@ -1090,8 +1105,17 @@ class AppController {
   Future<void> _initCore() async {
     final isInit = await clashCore.isInit;
     if (!isInit) {
-      await clashCore.init();
-      await clashCore.setState(globalState.getCoreState());
+      final initialized = await clashCore.init();
+      if (!initialized) {
+        throw StateError('Core initialization returned false');
+      }
+      final stateApplied = await clashCore.setState(globalState.getCoreState());
+      if (!stateApplied) {
+        throw StateError('Core state initialization returned false');
+      }
+      if (!await clashCore.isInit) {
+        throw StateError('Core did not confirm initialization');
+      }
     }
   }
 
@@ -1477,8 +1501,9 @@ class AppController {
       }
 
       if (successCount > 0) {
-        globalState.navigatorKey.currentState
-            ?.popUntil((route) => route.isFirst);
+        globalState.navigatorKey.currentState?.popUntil(
+          (route) => route.isFirst,
+        );
         toProfiles();
       }
     } finally {
@@ -2290,8 +2315,6 @@ class AppController {
     // Ensure current profile exists
     _ensureCurrentProfile(profiles);
   }
-
-
 
   Future<T?> safeRun<T>(
     FutureOr<T> Function() futureFunction, {

--- a/lib/manager/clash_manager.dart
+++ b/lib/manager/clash_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bett_box/clash/clash.dart';
 import 'package:bett_box/common/common.dart';
 import 'package:bett_box/enum/enum.dart';
@@ -32,8 +34,14 @@ class _ClashContainerState extends ConsumerState<ClashManager>
     ref.listenManual(needSetupProvider, (prev, next) {
       if (prev != next) {
         final profileChanged = prev?.a != next.a;
-        globalState.appController.handleChangeProfile(
-          hardRestart: system.isDesktop && profileChanged,
+        unawaited(
+          globalState.appController
+              .handleChangeProfile(
+                hardRestart: system.isDesktop && profileChanged,
+              )
+              .catchError((Object error, StackTrace stackTrace) {
+                commonPrint.log('Profile change failed: $error');
+              }),
         );
       }
     });

--- a/test/clash/core_startup_test.dart
+++ b/test/clash/core_startup_test.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:bett_box/clash/core_startup.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('waitForCoreReady returns the completed value', () async {
+    expect(await waitForCoreReady(Future.value(7)), 7);
+  });
+
+  test('waitForCoreReady reports a typed timeout', () async {
+    final ready = Completer<void>();
+
+    await expectLater(
+      waitForCoreReady(ready.future, timeout: Duration.zero),
+      throwsA(isA<CoreReadyTimeoutException>()),
+    );
+  });
+
+  test('CoreStartGuard always resets after an error', () async {
+    final guard = CoreStartGuard();
+
+    await expectLater(
+      guard.run<void>(() async => throw StateError('boom')),
+      throwsStateError,
+    );
+
+    expect(guard.isRunning, isFalse);
+    expect(await guard.run(() async => 9), 9);
+  });
+}


### PR DESCRIPTION
## Summary

Make Core startup/restart failures explicit and preserve useful diagnostics:

- propagate the 5-second IPC readiness timeout as a typed failure instead of logging and continuing;
- guard Core startup state with `try/finally`, so `isStarting` always resets;
- clean up a half-started Core while preserving the original startup error;
- make initial `preload()` wait for the first Core startup result;
- fail when Core initialization/state setup returns `false`;
- clear stale groups/providers at the start of a desktop profile hard switch;
- keep logs and requests instead of erasing the incident immediately after a switch;
- explicitly catch asynchronous profile-change failures;
- document that `checkCoreHealth()` checks only IPC/control-plane health, not TUN or mixed-port data-plane health.

This complements #209 but does not change profile apply ordering and does not add automatic restart/watchdog behavior.

## Why

In #330 the App, Core process, Helper and mixed-port listener can remain alive while TUN/mixed traffic is unavailable. Treating socket connection or `getIsInit` as proof of full health leaves the UI showing stale nodes/status and hides restart failures.

The change deliberately avoids automatic self-healing restarts: a failed restart can extend an outage, and silently restarting would erase useful evidence.

## Verification

- `dart format` on all five modified Dart files: clean;
- `dart analyze lib/clash/core_startup.dart`: no issues;
- standalone Dart 3.12.2 smoke coverage: normal completion, typed timeout, concurrent-start rejection, and state reset after success/failure: PASS;
- `git diff --check`: PASS.

Not run locally:

- full `flutter test` / whole-project analyze;
- Windows build or end-to-end TUN test.

The local environment did not have Flutter installed; this limitation is intentionally reported rather than treating the standalone Dart checks as a full Flutter build.

Related: #330, #209
