### PR TITLE
修复：macOS 网络切换与唤醒后恢复系统 DNS 和 TUN

### DIFF
--- a/lib/application.dart
+++ b/lib/application.dart
@@ -19,6 +19,22 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'controller.dart';
 import 'pages/pages.dart';
 
+bool shouldReconcileMacOSNetworkState({
+  required String? previousFingerprint,
+  required String currentFingerprint,
+  bool force = false,
+}) {
+  return force || previousFingerprint != currentFingerprint;
+}
+
+bool isMacOSNetworkRecoveryCurrent({
+  required bool mounted,
+  required int scheduledGeneration,
+  required int currentGeneration,
+}) {
+  return mounted && scheduledGeneration == currentGeneration;
+}
+
 class Application extends ConsumerStatefulWidget {
   const Application({super.key});
 
@@ -30,6 +46,11 @@ class ApplicationState extends ConsumerState<Application>
     with WidgetsBindingObserver {
   Timer? _autoUpdateGroupTaskTimer;
   Timer? _autoUpdateProfilesTaskTimer;
+  Timer? _networkChangeDebounceTimer;
+  int _networkChangeGeneration = 0;
+  bool _forceNextMacOSNetworkRecovery = false;
+  bool _macOSNetworkRecoveryReady = false;
+  String? _lastMacOSNetworkFingerprint;
 
   final _pageTransitionsTheme = const PageTransitionsTheme(
     builders: <TargetPlatform, PageTransitionsBuilder>{
@@ -54,6 +75,9 @@ class ApplicationState extends ConsumerState<Application>
     globalState.backgroundMode.addListener(_syncAutoUpdateTasks);
     _syncAutoUpdateTasks();
     globalState.appController = AppController(context, ref);
+    if (system.isMacOS) {
+      app.onSystemWake = _handleMacOSSystemWake;
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       unawaited(_initApp());
     });
@@ -71,6 +95,12 @@ class ApplicationState extends ConsumerState<Application>
       globalState.appController = AppController(currentContext, ref);
     }
     await globalState.appController.init();
+    if (system.isMacOS) {
+      final networkState = await macOS?.defaultNetworkState;
+      if (!mounted) return;
+      _lastMacOSNetworkFingerprint = networkState?.fingerprint;
+      _macOSNetworkRecoveryReady = true;
+    }
     try {
       await ExternalControl.start();
     } catch (e) {
@@ -133,6 +163,93 @@ class ApplicationState extends ConsumerState<Application>
     );
   }
 
+  void _handleConnectivityChanged(List<ConnectivityResult> results) {
+    if (!system.isMacOS) {
+      if (!results.contains(ConnectivityResult.vpn)) {
+        unawaited(clashCore.closeConnections());
+      }
+      globalState.appController.updateLocalIp();
+      globalState.appController.addCheckIpNumDebounce();
+      return;
+    }
+
+    unawaited(globalState.appController.updateLocalIp());
+    if (!_macOSNetworkRecoveryReady) return;
+    _scheduleMacOSNetworkRecovery();
+  }
+
+  void _handleMacOSSystemWake() {
+    if (!mounted || !system.isMacOS || !_macOSNetworkRecoveryReady) return;
+    commonPrint.log('macOS system wake detected; forcing TUN and DNS recovery');
+    _scheduleMacOSNetworkRecovery(force: true);
+  }
+
+  void _scheduleMacOSNetworkRecovery({bool force = false}) {
+    _forceNextMacOSNetworkRecovery |= force;
+    final generation = ++_networkChangeGeneration;
+    _networkChangeDebounceTimer?.cancel();
+    _networkChangeDebounceTimer = Timer(
+      const Duration(milliseconds: 500),
+      () => unawaited(_handleMacOSNetworkChange(generation)),
+    );
+  }
+
+  Future<void> _handleMacOSNetworkChange(int generation) async {
+    final networkState = await macOS?.waitForStableDefaultNetwork(
+      isCancelled: () => !isMacOSNetworkRecoveryCurrent(
+        mounted: mounted,
+        scheduledGeneration: generation,
+        currentGeneration: _networkChangeGeneration,
+      ),
+    );
+    if (networkState == null ||
+        !isMacOSNetworkRecoveryCurrent(
+          mounted: mounted,
+          scheduledGeneration: generation,
+          currentGeneration: _networkChangeGeneration,
+        )) {
+      return;
+    }
+
+    final force = _forceNextMacOSNetworkRecovery;
+    _forceNextMacOSNetworkRecovery = false;
+    if (!shouldReconcileMacOSNetworkState(
+      previousFingerprint: _lastMacOSNetworkFingerprint,
+      currentFingerprint: networkState.fingerprint,
+      force: force,
+    )) {
+      return;
+    }
+    try {
+      final recovered = await globalState.appController
+          .handleMacOSNetworkChange(
+            networkState,
+            isCancelled: () => !isMacOSNetworkRecoveryCurrent(
+              mounted: mounted,
+              scheduledGeneration: generation,
+              currentGeneration: _networkChangeGeneration,
+            ),
+          );
+      if (!recovered ||
+          !isMacOSNetworkRecoveryCurrent(
+            mounted: mounted,
+            scheduledGeneration: generation,
+            currentGeneration: _networkChangeGeneration,
+          )) {
+        _forceNextMacOSNetworkRecovery |= force;
+        return;
+      }
+      _lastMacOSNetworkFingerprint = networkState.fingerprint;
+    } catch (e) {
+      _forceNextMacOSNetworkRecovery |= force;
+      commonPrint.log('Failed to reconcile macOS network change: $e');
+      return;
+    }
+
+    unawaited(globalState.appController.updateLocalIp());
+    globalState.appController.addCheckIpNumDebounce();
+  }
+
   Widget _buildPlatformState(Widget child) {
     if (system.isDesktop) {
       return WindowManager(
@@ -152,21 +269,7 @@ class ApplicationState extends ConsumerState<Application>
     return AppStateManager(
       child: ClashManager(
         child: ConnectivityManager(
-          onConnectivityChanged: (results) async {
-            if (!results.contains(ConnectivityResult.vpn)) {
-              clashCore.closeConnections();
-            }
-            if (system.isMacOS) {
-              // Wait for DHCP and the default route to settle before moving the
-              // managed DNS from the previous network to the new one.
-              await Future.delayed(const Duration(seconds: 1));
-              if (!mounted) return;
-              final dnsState = ref.read(autoSetSystemDnsStateProvider);
-              await macOS?.updateDns(!(dnsState.a && dnsState.b));
-            }
-            globalState.appController.updateLocalIp();
-            globalState.appController.addCheckIpNumDebounce();
-          },
+          onConnectivityChanged: _handleConnectivityChanged,
           child: child,
         ),
       ),
@@ -257,11 +360,16 @@ class ApplicationState extends ConsumerState<Application>
 
   @override
   void dispose() {
+    if (system.isMacOS) {
+      app.onSystemWake = null;
+    }
     globalState.backgroundMode.removeListener(_syncAutoUpdateTasks);
     WidgetsBinding.instance.removeObserver(this);
     linkManager.destroy();
     _autoUpdateGroupTaskTimer?.cancel();
     _autoUpdateProfilesTaskTimer?.cancel();
+    _networkChangeDebounceTimer?.cancel();
+    _networkChangeGeneration++;
     ExternalControl.stop();
     if (!system.isAndroid && !globalState.isExiting) {
       unawaited(globalState.appController.handleExit());

--- a/lib/common/system.dart
+++ b/lib/common/system.dart
@@ -493,6 +493,16 @@ class Windows {
 
 final windows = system.isWindows ? Windows() : null;
 
+class MacOSNetworkState {
+  final String serviceName;
+  final String fingerprint;
+
+  const MacOSNetworkState({
+    required this.serviceName,
+    required this.fingerprint,
+  });
+}
+
 class MacOS {
   static MacOS? _instance;
   static const _dnsBackupFileName = 'macos_system_dns_backup.json';
@@ -506,23 +516,45 @@ class MacOS {
     return _instance!;
   }
 
-  Future<String?> get defaultServiceName async {
+  Future<({String device, String gateway})?> _getDefaultRoute() async {
     final result = await Process.run('route', ['-n', 'get', 'default']);
-    final output = result.stdout.toString();
-    final deviceLine = output
-        .split('\n')
-        .firstWhere((s) => s.contains('interface:'), orElse: () => '');
-    final parts = deviceLine.trim().split(' ');
-    if (parts.length != 2) return null;
+    if (result.exitCode != 0) return null;
 
-    final device = parts[1];
+    final output = result.stdout.toString();
+    String? valueForKey(String key) {
+      final prefix = '$key:';
+      final line = output
+          .split('\n')
+          .map((line) => line.trim())
+          .firstWhere((line) => line.startsWith(prefix), orElse: () => '');
+      if (line.isEmpty) return null;
+      return line.substring(prefix.length).trim();
+    }
+
+    final device = valueForKey('interface');
+    final gateway = valueForKey('gateway');
+    if (device == null ||
+        device.isEmpty ||
+        gateway == null ||
+        gateway.isEmpty) {
+      return null;
+    }
+    return (device: device, gateway: gateway);
+  }
+
+  Future<String?> _getServiceNameForDevice(String device) async {
     final serviceResult = await Process.run('networksetup', [
       '-listnetworkserviceorder',
     ]);
+    if (serviceResult.exitCode != 0) return null;
+
     final serviceOutput = serviceResult.stdout.toString();
     final currentService = serviceOutput
         .split('\n\n')
-        .firstWhere((s) => s.contains('Device: $device'), orElse: () => '');
+        .firstWhere(
+          (section) => section.contains('Device: $device)'),
+          orElse: () => '',
+        );
     if (currentService.isEmpty) return null;
 
     final serviceNameLine = currentService
@@ -535,6 +567,101 @@ class MacOS {
       r'^\(\d+\)\s+(.+)$',
     ).firstMatch(serviceNameLine.trim());
     return match?.group(1)?.trim();
+  }
+
+  Future<String?> get defaultServiceName async {
+    final route = await _getDefaultRoute();
+    if (route == null) return null;
+    return _getServiceNameForDevice(route.device);
+  }
+
+  Future<MacOSNetworkState?> _getDefaultNetworkState() async {
+    final route = await _getDefaultRoute();
+    if (route == null) return null;
+
+    final serviceName = await _getServiceNameForDevice(route.device);
+    if (serviceName == null) return null;
+
+    final addressResult = await Process.run('ipconfig', [
+      'getifaddr',
+      route.device,
+    ]);
+    final address = addressResult.exitCode == 0
+        ? addressResult.stdout.toString().trim()
+        : '';
+    if (address.isEmpty) return null;
+
+    final summaryResult = await Process.run('ipconfig', [
+      'getsummary',
+      route.device,
+    ]);
+    final summary = summaryResult.exitCode == 0
+        ? summaryResult.stdout.toString()
+        : '';
+
+    String summaryValue(RegExp pattern) {
+      return pattern.firstMatch(summary)?.group(1)?.trim() ?? '';
+    }
+
+    final connectionId = summaryValue(
+      RegExp(r'^\s*ConnectionID\s*:\s*(.+)$', multiLine: true),
+    );
+    final dhcpServer = summaryValue(
+      RegExp(r'^\s*server_identifier \(ip\):\s*(.+)$', multiLine: true),
+    );
+    final dhcpDns = summaryValue(
+      RegExp(r'^\s*domain_name_server \(ip_mult\):\s*(.+)$', multiLine: true),
+    );
+    final fingerprint = [
+      route.device,
+      route.gateway,
+      serviceName,
+      address,
+      connectionId,
+      dhcpServer,
+      dhcpDns,
+    ].join('|');
+
+    return MacOSNetworkState(
+      serviceName: serviceName,
+      fingerprint: fingerprint,
+    );
+  }
+
+  Future<MacOSNetworkState?> get defaultNetworkState =>
+      _getDefaultNetworkState();
+
+  Future<MacOSNetworkState?> waitForStableDefaultNetwork({
+    Duration initialDelay = const Duration(seconds: 1),
+    Duration sampleInterval = const Duration(seconds: 1),
+    int maxAttempts = 5,
+    bool Function()? isCancelled,
+  }) async {
+    await Future.delayed(initialDelay);
+    MacOSNetworkState? previous;
+
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      if (isCancelled?.call() == true) return null;
+
+      final current = await _getDefaultNetworkState();
+      if (current != null &&
+          previous != null &&
+          current.fingerprint == previous.fingerprint) {
+        return current;
+      }
+      previous = current;
+
+      if (attempt < maxAttempts - 1) {
+        await Future.delayed(sampleInterval);
+      }
+    }
+
+    if (previous != null) {
+      commonPrint.log(
+        'macOS default network did not fully settle; using the latest state',
+      );
+    }
+    return previous;
   }
 
   Future<List<String>?> get systemDns async {
@@ -560,26 +687,29 @@ class MacOS {
         : output.split('\n');
   }
 
-  Future<void> updateDns(bool restore) {
+  Future<void> updateDns(bool restore, {String? serviceName}) {
     return _dnsLock.synchronized(() async {
       if (restore) {
         await _restoreDns();
       } else {
-        await _setDns();
+        await _setDns(serviceName);
       }
     });
   }
 
-  Future<void> _setDns() async {
+  Future<void> _setDns(String? targetServiceName) async {
     // Restore a previous managed value first so repeated enable operations never
     // overwrite the real system DNS backup with Bettbox's own hijack DNS.
     if (!await _restoreDns()) return;
 
-    final serviceName = await defaultServiceName;
+    final serviceName = targetServiceName ?? await defaultServiceName;
     if (serviceName == null) return;
 
     final currentDns = await _getSystemDns(serviceName);
-    if (currentDns == null || currentDns.contains(_hijackDns)) return;
+    if (currentDns == null ||
+        (currentDns.length == 1 && currentDns.single == _hijackDns)) {
+      return;
+    }
 
     final backup = jsonEncode({
       'serviceName': serviceName,
@@ -599,7 +729,6 @@ class MacOS {
     final result = await Process.run('networksetup', [
       '-setdnsservers',
       serviceName,
-      ...currentDns,
       _hijackDns,
     ]);
     if (result.exitCode != 0) {

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -30,6 +30,70 @@ import 'common/flclash_database_extractor.dart';
 import 'models/models.dart';
 import 'views/profiles/override_profile.dart';
 
+@visibleForTesting
+Future<bool> runMacOSTunStartup({
+  required Future<Result<bool>> Function() requestAdmin,
+  required Future<void> Function() restartCore,
+  required Future<void> Function() applyTunConfig,
+  required Future<void> Function() startListener,
+  required Future<void> Function() stopListener,
+}) async {
+  final result = await requestAdmin();
+  if (result.isError) {
+    return false;
+  }
+
+  if (result.needRestart) {
+    await restartCore();
+  }
+
+  await startListener();
+  try {
+    await applyTunConfig();
+  } catch (error, stackTrace) {
+    try {
+      await stopListener();
+    } catch (_) {}
+    Error.throwWithStackTrace(error, stackTrace);
+  }
+
+  return true;
+}
+
+@visibleForTesting
+Future<void> rebuildMacOSTunListener({
+  required Future<void> Function() disableTun,
+  required Future<void> Function() stopListener,
+  required Future<void> Function() repairNetwork,
+  required Future<void> Function() startListener,
+  required Future<void> Function() enableTun,
+  bool Function()? shouldResume,
+}) async {
+  var tunTemporarilyDisabled = false;
+  var listenerStopped = false;
+  try {
+    await disableTun();
+    tunTemporarilyDisabled = true;
+    await stopListener();
+    listenerStopped = true;
+    await repairNetwork();
+  } finally {
+    if (shouldResume?.call() ?? true) {
+      if (listenerStopped) {
+        try {
+          await startListener();
+        } finally {
+          if (tunTemporarilyDisabled) {
+            await enableTun();
+          }
+        }
+      } else if (tunTemporarilyDisabled) {
+        await enableTun();
+      }
+    }
+  }
+}
+
 class AppController {
   int? lastProfileModified;
 
@@ -47,6 +111,7 @@ class AppController {
   Timer? _updateGroupsRetryTimer;
   int _coreGeneration = 0;
   int _setupGeneration = 0;
+  int _macOSNetworkRecoveryGeneration = 0;
 
   AppController(this.context, WidgetRef ref) : _ref = ref;
 
@@ -165,7 +230,69 @@ class AppController {
   }
 
   Future<void> updateStatus(bool isStart) {
+    if (system.isMacOS && !isStart) {
+      _macOSNetworkRecoveryGeneration++;
+    }
     return _coreLifecycleLock.synchronized(() => _updateStatus(isStart));
+  }
+
+  Future<bool> handleMacOSNetworkChange(
+    MacOSNetworkState networkState, {
+    bool Function()? isCancelled,
+  }) {
+    if (!system.isMacOS) return Future.value(false);
+
+    final recoveryGeneration = _macOSNetworkRecoveryGeneration;
+
+    bool recoveryCancelled() {
+      return recoveryGeneration != _macOSNetworkRecoveryGeneration ||
+          isCancelled?.call() == true;
+    }
+
+    return _coreLifecycleLock.synchronized(() async {
+      if (recoveryCancelled()) return false;
+
+      final isStart = _ref.read(runTimeProvider.notifier).isStart;
+      final dnsState = _ref.read(autoSetSystemDnsStateProvider);
+      final shouldSetSystemDns = dnsState.a && dnsState.b;
+      final shouldRestartTunListener = isStart && dnsState.a;
+
+      Future<void> repairNetwork() async {
+        if (recoveryCancelled()) return;
+
+        if (isStart) {
+          await clashCore.closeConnections();
+        }
+        if (recoveryCancelled()) return;
+
+        await macOS?.updateDns(
+          !shouldSetSystemDns,
+          serviceName: networkState.serviceName,
+        );
+
+        if (!isStart || recoveryCancelled()) return;
+
+        await clashCore.flushDnsCache();
+        if (recoveryCancelled()) return;
+        await clashCore.flushFakeIP();
+      }
+
+      if (!shouldRestartTunListener) {
+        await repairNetwork();
+        return !recoveryCancelled();
+      }
+
+      commonPrint.log('Rebuilding macOS TUN after network change');
+      await rebuildMacOSTunListener(
+        disableTun: () => _applyCoreTunConfig(false, persist: false),
+        stopListener: clashCore.stopListener,
+        repairNetwork: repairNetwork,
+        startListener: clashCore.startListener,
+        enableTun: _updateClashConfig,
+        shouldResume: () => !recoveryCancelled(),
+      );
+      return !recoveryCancelled();
+    });
   }
 
   Future<void> _updateStatus(bool isStart) async {
@@ -192,34 +319,36 @@ class AppController {
     final isDesktop = system.isDesktop;
 
     if (isDesktop && patchConfig.tun.enable) {
-      await _quickSetupConfig(enableTun: false);
+      final setupResult = await _quickSetupConfig(enableTun: false);
+      if (system.isMacOS && setupResult != true) {
+        commonPrint.log('Fast start aborted: initial TUN setup failed');
+        return;
+      }
 
       if (system.isMacOS) {
         try {
-          final res = await _requestAdmin(true);
-          if (res.needRestart) {
-            await restartCore();
+          final started = await runMacOSTunStartup(
+            requestAdmin: () => _requestAdmin(true),
+            restartCore: restartCore,
+            applyTunConfig: _updateClashConfig,
+            startListener: clashCore.startListener,
+            stopListener: clashCore.stopListener,
+          );
+          if (!started) {
+            commonPrint.log(
+              'Fast start aborted: macOS TUN authorization failed',
+            );
             return;
           }
-          await globalState.handleStart([updateRunTime, updateTraffic]);
-          await updateProviders();
-          if (!res.isError) {
-            Future.microtask(() async {
-              try {
-                await _updateClashConfig();
-              } catch (e) {
-                commonPrint.log('FastStart macOS TUN update failed: $e');
-              }
-              _backgroundLoad();
-            });
-          } else {
-            _backgroundLoad();
-          }
-        } catch (e) {
-          commonPrint.log('FastStart macOS auth error: $e');
-          await globalState.handleStart([updateRunTime, updateTraffic]);
+          await globalState.handleStartWithActiveListener([
+            updateRunTime,
+            updateTraffic,
+          ]);
           await updateProviders();
           _backgroundLoad();
+        } catch (e) {
+          commonPrint.log('FastStart macOS TUN startup failed: $e');
+          rethrow;
         }
         _scheduleCheckIpRefresh();
         return;
@@ -583,14 +712,19 @@ class AppController {
       return;
     }
 
+    await _applyCoreTunConfig(realTunEnable);
+  }
+
+  Future<void> _applyCoreTunConfig(bool enable, {bool persist = true}) async {
+    final updateParams = _ref.read(updateParamsProvider);
     final message = await clashCore.updateConfig(
-      updateParams.copyWith.tun(enable: realTunEnable),
+      updateParams.copyWith.tun(enable: enable),
     );
     if (message.isNotEmpty) throw message;
 
-    if (system.isDesktop) {
+    if (persist && system.isDesktop) {
       final prefs = await preferences.sharedPreferencesCompleter.future;
-      await prefs?.setBool('is_tun_running', realTunEnable);
+      await prefs?.setBool('is_tun_running', enable);
     }
   }
 
@@ -967,6 +1101,9 @@ class AppController {
     final exitLock = Completer<void>();
     _exitLock = exitLock;
     globalState.isExiting = true;
+    if (system.isMacOS) {
+      _macOSNetworkRecoveryGeneration++;
+    }
 
     try {
       if (system.isDesktop) {

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -67,7 +67,7 @@ Future<void> rebuildMacOSTunListener({
   required Future<void> Function() repairNetwork,
   required Future<void> Function() startListener,
   required Future<void> Function() enableTun,
-  bool Function()? shouldResume,
+  bool Function()? isLifecycleCancelled,
 }) async {
   var tunTemporarilyDisabled = false;
   var listenerStopped = false;
@@ -78,7 +78,9 @@ Future<void> rebuildMacOSTunListener({
     listenerStopped = true;
     await repairNetwork();
   } finally {
-    if (shouldResume?.call() ?? true) {
+    // Once teardown has started, a newer network event must not leave the
+    // listener or TUN disabled. Only an explicit stop/exit may keep them off.
+    if (!(isLifecycleCancelled?.call() ?? false)) {
       if (listenerStopped) {
         try {
           await startListener();
@@ -244,9 +246,12 @@ class AppController {
 
     final recoveryGeneration = _macOSNetworkRecoveryGeneration;
 
+    bool lifecycleCancelled() {
+      return recoveryGeneration != _macOSNetworkRecoveryGeneration;
+    }
+
     bool recoveryCancelled() {
-      return recoveryGeneration != _macOSNetworkRecoveryGeneration ||
-          isCancelled?.call() == true;
+      return lifecycleCancelled() || isCancelled?.call() == true;
     }
 
     return _coreLifecycleLock.synchronized(() async {
@@ -289,7 +294,7 @@ class AppController {
         repairNetwork: repairNetwork,
         startListener: clashCore.startListener,
         enableTun: _updateClashConfig,
-        shouldResume: () => !recoveryCancelled(),
+        isLifecycleCancelled: lifecycleCancelled,
       );
       return !recoveryCancelled();
     });

--- a/lib/manager/connectivity_manager.dart
+++ b/lib/manager/connectivity_manager.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import 'package:flutter/material.dart';
 
 class ConnectivityManager extends StatefulWidget {
@@ -18,12 +20,15 @@ class ConnectivityManager extends StatefulWidget {
 }
 
 class _ConnectivityManagerState extends State<ConnectivityManager> {
-  late StreamSubscription subscription;
+  late StreamSubscription<List<ConnectivityResult>> subscription;
 
   @override
   void initState() {
     super.initState();
-    subscription = Connectivity().onConnectivityChanged.listen((results) async {
+    final connectivityStream = Platform.isMacOS
+        ? ConnectivityPlatform.instance.onConnectivityChanged
+        : Connectivity().onConnectivityChanged;
+    subscription = connectivityStream.listen((results) {
       widget.onConnectivityChanged?.call(results);
     });
   }

--- a/lib/plugins/app.dart
+++ b/lib/plugins/app.dart
@@ -9,23 +9,28 @@ class App {
   static App? _instance;
   late MethodChannel methodChannel;
   Function()? onExit;
+  FutureOr<void> Function()? onSystemWake;
 
   App._internal() {
     methodChannel = const MethodChannel('app');
-    methodChannel.setMethodCallHandler((call) async {
-      switch (call.method) {
-        case 'exit':
-          await onExit?.call();
-        case 'getText':
-          try {
-            return Intl.message(call.arguments as String);
-          } catch (_) {
-            return '';
-          }
-        default:
-          throw MissingPluginException();
-      }
-    });
+    methodChannel.setMethodCallHandler(handleMethodCall);
+  }
+
+  Future<dynamic> handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'exit':
+        await onExit?.call();
+      case 'systemDidWake':
+        await onSystemWake?.call();
+      case 'getText':
+        try {
+          return Intl.message(call.arguments as String);
+        } catch (_) {
+          return '';
+        }
+      default:
+        throw MissingPluginException();
+    }
   }
 
   factory App() {

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -291,12 +291,19 @@ class GlobalState {
     UpdateTasks? tasks,
     bool includeVpnService = true,
   ]) async {
-    startTime ??= DateTime.now();
     if (system.isAndroid && isService) {
       await clashLibHandler?.startListener();
     } else {
       await clashCore.startListener();
     }
+    await handleStartWithActiveListener(tasks, includeVpnService);
+  }
+
+  Future<void> handleStartWithActiveListener([
+    UpdateTasks? tasks,
+    bool includeVpnService = true,
+  ]) async {
+    startTime ??= DateTime.now();
     if (includeVpnService) {
       await service?.startVpn();
     }

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -5,6 +5,7 @@ import LaunchAtLogin
 
 class MainFlutterWindow: NSWindow {
     private var appMethodChannel: FlutterMethodChannel?
+    private var systemDidWakeObserver: NSObjectProtocol?
     
     override func awakeFromNib() {
         let flutterViewController = FlutterViewController()
@@ -31,6 +32,7 @@ class MainFlutterWindow: NSWindow {
         
         // Setup app method channel
         setupAppMethodChannel(flutterViewController: flutterViewController)
+        setupSystemWakeNotification()
         
         RegisterGeneratedPlugins(registry: flutterViewController)
         
@@ -40,6 +42,12 @@ class MainFlutterWindow: NSWindow {
         }
         
         super.awakeFromNib()
+    }
+
+    deinit {
+        if let observer = systemDidWakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
     }
     
     override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
@@ -73,6 +81,16 @@ class MainFlutterWindow: NSWindow {
             default:
                 result(FlutterMethodNotImplemented)
             }
+        }
+    }
+
+    private func setupSystemWakeNotification() {
+        systemDidWakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.appMethodChannel?.invokeMethod("systemDidWake", arguments: nil)
         }
     }
     

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,7 +249,7 @@ packages:
     source: hosted
     version: "7.0.0"
   connectivity_plus_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: connectivity_plus_platform_interface
       sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   sqflite_common_ffi: ^2.4.2
   yaml: ^3.1.2
   connectivity_plus: 7.0.0
+  connectivity_plus_platform_interface: 2.1.0
   screen_retriever: ^0.2.0
   defer_pointer: ^0.0.2
   flutter_riverpod: ^2.6.1

--- a/test/application/macos_network_recovery_test.dart
+++ b/test/application/macos_network_recovery_test.dart
@@ -1,0 +1,56 @@
+import 'package:bett_box/application.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('macOS network recovery', () {
+    test('skips an unchanged network during regular connectivity updates', () {
+      expect(
+        shouldReconcileMacOSNetworkState(
+          previousFingerprint: 'same-network',
+          currentFingerprint: 'same-network',
+        ),
+        isFalse,
+      );
+    });
+
+    test('forces recovery after wake even when the network is unchanged', () {
+      expect(
+        shouldReconcileMacOSNetworkState(
+          previousFingerprint: 'same-network',
+          currentFingerprint: 'same-network',
+          force: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('recovers when the network fingerprint changes', () {
+      expect(
+        shouldReconcileMacOSNetworkState(
+          previousFingerprint: 'old-network',
+          currentFingerprint: 'new-network',
+        ),
+        isTrue,
+      );
+    });
+
+    test('drops a queued recovery after a newer event arrives', () {
+      expect(
+        isMacOSNetworkRecoveryCurrent(
+          mounted: true,
+          scheduledGeneration: 3,
+          currentGeneration: 4,
+        ),
+        isFalse,
+      );
+      expect(
+        isMacOSNetworkRecoveryCurrent(
+          mounted: true,
+          scheduledGeneration: 4,
+          currentGeneration: 4,
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/controller/macos_tun_startup_test.dart
+++ b/test/controller/macos_tun_startup_test.dart
@@ -1,0 +1,188 @@
+import 'package:bett_box/controller.dart';
+import 'package:bett_box/models/models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('macOS TUN startup', () {
+    test('starts the listener before applying TUN', () async {
+      final events = <String>[];
+
+      final started = await runMacOSTunStartup(
+        requestAdmin: () async {
+          events.add('authorize');
+          return Result.success(true);
+        },
+        restartCore: () async => events.add('restart'),
+        applyTunConfig: () async => events.add('apply'),
+        startListener: () async => events.add('start'),
+        stopListener: () async => events.add('stop'),
+      );
+
+      expect(started, isTrue);
+      expect(events, ['authorize', 'start', 'apply']);
+    });
+
+    test(
+      'restarts, starts, then reapplies TUN after new authorization',
+      () async {
+        final events = <String>[];
+
+        final started = await runMacOSTunStartup(
+          requestAdmin: () async {
+            events.add('authorize');
+            return Result.success(true, needRestart: true);
+          },
+          restartCore: () async => events.add('restart'),
+          applyTunConfig: () async => events.add('apply'),
+          startListener: () async => events.add('start'),
+          stopListener: () async => events.add('stop'),
+        );
+
+        expect(started, isTrue);
+        expect(events, ['authorize', 'restart', 'start', 'apply']);
+      },
+    );
+
+    test('does not start when authorization fails', () async {
+      final events = <String>[];
+
+      final started = await runMacOSTunStartup(
+        requestAdmin: () async {
+          events.add('authorize');
+          return Result<bool>.error('authorization failed');
+        },
+        restartCore: () async => events.add('restart'),
+        applyTunConfig: () async => events.add('apply'),
+        startListener: () async => events.add('start'),
+        stopListener: () async => events.add('stop'),
+      );
+
+      expect(started, isFalse);
+      expect(events, ['authorize']);
+    });
+
+    test('stops the listener when applying TUN fails', () async {
+      final events = <String>[];
+
+      await expectLater(
+        runMacOSTunStartup(
+          requestAdmin: () async {
+            events.add('authorize');
+            return Result.success(true);
+          },
+          restartCore: () async => events.add('restart'),
+          applyTunConfig: () async {
+            events.add('apply');
+            throw StateError('apply failed');
+          },
+          startListener: () async => events.add('start'),
+          stopListener: () async => events.add('stop'),
+        ),
+        throwsStateError,
+      );
+
+      expect(events, ['authorize', 'start', 'apply', 'stop']);
+    });
+
+    test('does not start when restarting the core fails', () async {
+      final events = <String>[];
+
+      await expectLater(
+        runMacOSTunStartup(
+          requestAdmin: () async {
+            events.add('authorize');
+            return Result.success(true, needRestart: true);
+          },
+          restartCore: () async {
+            events.add('restart');
+            throw StateError('restart failed');
+          },
+          applyTunConfig: () async => events.add('apply'),
+          startListener: () async => events.add('start'),
+          stopListener: () async => events.add('stop'),
+        ),
+        throwsStateError,
+      );
+
+      expect(events, ['authorize', 'restart']);
+    });
+  });
+
+  group('macOS TUN listener rebuild', () {
+    test(
+      'forces a disabled-to-enabled transition around network repair',
+      () async {
+        final events = <String>[];
+
+        await rebuildMacOSTunListener(
+          disableTun: () async => events.add('disable'),
+          stopListener: () async => events.add('stop'),
+          repairNetwork: () async => events.add('repair'),
+          startListener: () async => events.add('start'),
+          enableTun: () async => events.add('enable'),
+        );
+
+        expect(events, ['disable', 'stop', 'repair', 'start', 'enable']);
+      },
+    );
+
+    test('restores the listener and TUN when network repair fails', () async {
+      final events = <String>[];
+
+      await expectLater(
+        rebuildMacOSTunListener(
+          disableTun: () async => events.add('disable'),
+          stopListener: () async => events.add('stop'),
+          repairNetwork: () async {
+            events.add('repair');
+            throw StateError('repair failed');
+          },
+          startListener: () async => events.add('start'),
+          enableTun: () async => events.add('enable'),
+        ),
+        throwsStateError,
+      );
+
+      expect(events, ['disable', 'stop', 'repair', 'start', 'enable']);
+    });
+
+    test('reenables TUN when stopping the listener fails', () async {
+      final events = <String>[];
+
+      await expectLater(
+        rebuildMacOSTunListener(
+          disableTun: () async => events.add('disable'),
+          stopListener: () async {
+            events.add('stop');
+            throw StateError('stop failed');
+          },
+          repairNetwork: () async => events.add('repair'),
+          startListener: () async => events.add('start'),
+          enableTun: () async => events.add('enable'),
+        ),
+        throwsStateError,
+      );
+
+      expect(events, ['disable', 'stop', 'enable']);
+    });
+
+    test('does not reenable TUN after a manual stop takes priority', () async {
+      final events = <String>[];
+      var shouldResume = true;
+
+      await rebuildMacOSTunListener(
+        disableTun: () async => events.add('disable'),
+        stopListener: () async {
+          events.add('stop');
+          shouldResume = false;
+        },
+        repairNetwork: () async => events.add('repair'),
+        startListener: () async => events.add('start'),
+        enableTun: () async => events.add('enable'),
+        shouldResume: () => shouldResume,
+      );
+
+      expect(events, ['disable', 'stop', 'repair']);
+    });
+  });
+}

--- a/test/controller/macos_tun_startup_test.dart
+++ b/test/controller/macos_tun_startup_test.dart
@@ -166,20 +166,43 @@ void main() {
       expect(events, ['disable', 'stop', 'enable']);
     });
 
+    test(
+      'restores listener and TUN when a newer network event supersedes repair',
+      () async {
+        final events = <String>[];
+        var networkRequestSuperseded = false;
+
+        await rebuildMacOSTunListener(
+          disableTun: () async => events.add('disable'),
+          stopListener: () async => events.add('stop'),
+          repairNetwork: () async {
+            events.add('repair');
+            networkRequestSuperseded = true;
+          },
+          startListener: () async => events.add('start'),
+          enableTun: () async => events.add('enable'),
+          isLifecycleCancelled: () => false,
+        );
+
+        expect(networkRequestSuperseded, isTrue);
+        expect(events, ['disable', 'stop', 'repair', 'start', 'enable']);
+      },
+    );
+
     test('does not reenable TUN after a manual stop takes priority', () async {
       final events = <String>[];
-      var shouldResume = true;
+      var lifecycleCancelled = false;
 
       await rebuildMacOSTunListener(
         disableTun: () async => events.add('disable'),
         stopListener: () async {
           events.add('stop');
-          shouldResume = false;
+          lifecycleCancelled = true;
         },
         repairNetwork: () async => events.add('repair'),
         startListener: () async => events.add('start'),
         enableTun: () async => events.add('enable'),
-        shouldResume: () => shouldResume,
+        isLifecycleCancelled: () => lifecycleCancelled,
       );
 
       expect(events, ['disable', 'stop', 'repair']);

--- a/test/plugins/app_test.dart
+++ b/test/plugins/app_test.dart
@@ -1,0 +1,22 @@
+import 'package:bett_box/plugins/app.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    app.onSystemWake = null;
+  });
+
+  test('forwards the native macOS wake event', () async {
+    var wakeCount = 0;
+    app.onSystemWake = () async {
+      wakeCount++;
+    };
+
+    await app.handleMethodCall(const MethodCall('systemDidWake'));
+
+    expect(wakeCount, 1);
+  });
+}


### PR DESCRIPTION
## 背景

这是对 #319 的后续修复。

上游已通过 `00bd2157` 采纳了原 #320 中的系统 DNS 备份/恢复、退出恢复以及 TUN/总开关联动逻辑。本 PR 基于当前最新 `main`（`e553fe2b`）重新整理，不重复提交或描述这些已合入内容，只处理 macOS 在运行期间发生网络环境变化时的恢复问题。

典型场景均已脱敏：

- 从 Wi-Fi「网络 A」切换到同类型的 Wi-Fi「网络 B」后，系统 DNS 虽然仍显示 `223.5.5.5`，但部分 DIRECT 请求持续 DNS 超时；重新切换 TUN 后恢复。
- 电脑锁屏或休眠后唤醒，代理流量可能正常，但部分 DIRECT 域名出现 DNS 超时；重新切换 TUN 后恢复。
- 覆盖安装并重新授权辅助工具后，总开关与 TUN 设置均显示开启，但数据面未完整恢复；必须再次切换 TUN 才能联网。
- 网络恢复进行期间执行停止或退出，旧恢复任务可能与停止流程竞争，导致开关长时间不可操作或旧任务重新启用 TUN。

相关修复版本已在真实使用环境中持续验证 2～3 天，上述场景未再次复现。

## 与此前提交的关系

#320 虽然处于关闭状态，但维护者已通过 `00bd2157` 合入等价实现。本 PR 已排除其中的 DNS 备份、恢复、退出清理和开关联动代码，不会重复提交或重复描述已采纳内容。

## 源代码存在的问题与修复

### 1. 同类型 Wi-Fi 切换可能没有进入恢复回调

源代码使用：

```dart
Connectivity().onConnectivityChanged.listen(...)
```

`connectivity_plus` 的公开流会对连接类型列表执行去重。Wi-Fi「网络 A」切换到 Wi-Fi「网络 B」时，前后类型都可能仍为 `[wifi]`，事件因而被过滤，回调内的固定延迟和 `updateDns()` 根本不会执行。

macOS 新逻辑改为监听平台原始事件，其他平台仍保留原实现：

```dart
final connectivityStream = Platform.isMacOS
    ? ConnectivityPlatform.instance.onConnectivityChanged
    : Connectivity().onConnectivityChanged;
```

这项改动只绕过 macOS 上的 Dart 层去重，不改变 Android、Windows、Linux 等平台的事件语义。

### 2. 固定等待 1 秒无法确认 DHCP、默认路由和网络服务已经稳定

源代码在收到事件后固定等待 1 秒，再按当时的默认路由更新 DNS。网络切换过程中，这一时刻仍可能读到旧接口、旧网关或未完成的 DHCP 信息。

新逻辑读取并比较两次默认网络指纹：

```dart
final fingerprint = [
  route.device,
  route.gateway,
  serviceName,
  address,
  connectionId,
  dhcpServer,
  dhcpDns,
].join('|');
```

```dart
await macOS?.waitForStableDefaultNetwork(
  isCancelled: () => scheduledGeneration != currentGeneration,
);
```

只有连续采样一致后才优先执行恢复；最多重试 5 次，并允许更新的网络事件取消旧任务。这样既能识别同一接口上的 Wi-Fi/租约变化，也避免把 DNS 写入刚刚失效的网络服务。

### 3. 系统 DNS 需要从旧服务迁移到当前服务

原有备份/恢复能力已经由上游实现，但网络切换时 `_setDns()` 会再次自行查找默认服务，恢复流程与写入流程之间若默认路由继续变化，可能操作不同服务。

新逻辑把稳定采样得到的服务名传入同一 DNS 临界区：

```dart
await macOS?.updateDns(
  !shouldSetSystemDns,
  serviceName: networkState.serviceName,
);
```

启用自动系统 DNS 时，当前服务只写入 Bettbox 接管地址：

```dart
networksetup -setdnsservers <当前服务> 223.5.5.5
```

原始 DNS 仍沿用上游现有逻辑持久化备份，并在停用、退出或迁移服务时恢复。这样避免 DHCP DNS 排在 `223.5.5.5` 前面绕过接管，同时没有改变关闭 Bettbox 后由系统自动获取 DNS 的行为。

### 4. 只刷新 DNS/连接无法修复失效的 TUN 数据面

源代码在网络变化后主要关闭连接并重写系统 DNS。实际故障中，Mihomo 的 TUN listener、默认出口和路由仍可能保留切换前状态，因此会出现“系统 DNS 正确，但必须手动切换 TUN 才恢复”的现象。

新逻辑在 Bettbox 已启动且 TUN 已开启时执行一次受控重建：

```dart
await rebuildMacOSTunListener(
  disableTun: () => _applyCoreTunConfig(false, persist: false),
  stopListener: clashCore.stopListener,
  repairNetwork: repairNetwork,
  startListener: clashCore.startListener,
  enableTun: _updateClashConfig,
);
```

恢复顺序为：临时关闭 Core TUN → 停止 listener → 关闭旧连接并迁移系统 DNS → 清理 Core DNS/Fake-IP 缓存 → 重启 listener → 重新应用 TUN。临时关闭不会写入用户偏好，因此不会把恢复过程误保存为用户主动关闭 TUN。

### 5. 覆盖安装并授权辅助工具后的 TUN 启动顺序不完整

源代码可能先进入全局启动流程，再异步应用 TUN；如果授权过程要求重启 Core，listener 和配置应用之间会出现时序窗口，界面状态可能已开启，但 TUN 数据面没有完整建立。

新逻辑把 macOS 启动调整为原子顺序：

```dart
授权辅助工具
→ 必要时重启 Core
→ 启动 listener
→ 应用 TUN 配置
→ 更新运行状态
```

任一步失败都会显式中止；若应用 TUN 失败，会停止刚启动的 listener，避免留下半启动状态。非 macOS 的启动路径保持上游行为。

### 6. macOS 唤醒不一定产生可用的网络类型事件

锁屏/休眠后，网络类型和默认网络指纹都可能与休眠前相同，但底层 socket、路由或 TUN 状态已经失效。仅监听 connectivity 事件无法可靠覆盖这一场景。

本 PR 在 macOS 原生层监听：

```swift
NSWorkspace.didWakeNotification
```

事件通过现有 `app` MethodChannel 发送到 Dart，并强制执行一次稳定检测与恢复；Swift 观察者在窗口释放时同步注销。该桥接仅存在于 macOS Runner。

### 7. 新网络事件与手动停止不能共用同一种取消语义

网络连续变化可能排队多个恢复任务；若用户主动停止或退出，较旧任务不应在停止完成后重新开启 listener/TUN。源代码最初使用同一个 `recoveryCancelled()` 同时表示“出现了更新的网络事件”和“用户主动停止/退出”，并把它传给 TUN 重建的 `finally`。

唤醒恢复会主动关闭旧 TUN，这个动作本身也可能产生 connectivity 事件。新事件递增调度 generation 后，正在执行的恢复会被判定为过期；旧实现随后跳过 `startListener()` 和重新启用 TUN，可能留下“旧 TUN 已关闭、新 TUN 未启动”的半完成状态。此时日志可出现 `batch read packet: bad file descriptor`，界面仍显示运行，但实际流量需要重新加载 Core 才能恢复。

修复将取消条件拆为两级：

```dart
bool lifecycleCancelled() {
  return recoveryGeneration != _macOSNetworkRecoveryGeneration;
}

bool recoveryCancelled() {
  return lifecycleCancelled() || isCancelled?.call() == true;
}
```

- 更新的网络事件仍会使旧任务结果失效，并由最新任务继续协调网络；但只要 TUN teardown 已经开始，`finally` 必须先恢复 listener/TUN，不能把数据面留在关闭状态。
- 只有用户主动停止或退出导致的 lifecycle cancellation，才允许 `finally` 保持 listener/TUN 关闭。

```dart
isLifecycleCancelled: lifecycleCancelled,
```

这样既保留“手动停止优先于后台恢复”的原设计，也避免唤醒恢复被自身产生的 connectivity 事件打断。

## 平台边界与明确排除项

- 网络稳定检测、系统 DNS 服务迁移、TUN 重建和唤醒恢复均通过 macOS 平台判断进入。
- 非 macOS 平台继续使用原 connectivity 流和原启动流程。
- 不修改或注入 `proxy-server-nameserver`；此前相关现象已确认来自用户配置，不属于 Bettbox 代码问题。
- 不监控配置引用的辅助网卡，也不加入 DHCP DNS fallback；相关现象最终由企业网络认证状态解释，不能作为通用代码修复依据。
- 不回移 Mihomo Core 的 DNS/sniffer 补丁。

## 验证

- `flutter analyze`：通过，无问题。
- `flutter test`：20/20 通过。
- 新增测试覆盖：同类型网络去重后的恢复判定、唤醒强制恢复、过期任务取消、macOS TUN 原子启动、listener 重建失败回滚、更新网络事件到达后仍恢复 TUN、手动停止优先级及原生唤醒事件转发。
- 自定义构建版本已在真实网络切换、锁屏/唤醒和覆盖安装场景中持续使用 2～3 天，原问题未再次复现。

Follow-up to #319
