### PR TITLE
修复：macOS Command+W 在切换搜索页面后无法关闭窗口

### DIFF
--- a/lib/manager/hotkey_manager.dart
+++ b/lib/manager/hotkey_manager.dart
@@ -72,8 +72,9 @@ class _HotKeyManagerState extends ConsumerState<HotKeyManager> {
   Shortcuts _buildShortcuts(Widget child) {
     return Shortcuts(
       shortcuts: {
-        utils.controlSingleActivator(LogicalKeyboardKey.keyW):
-            CloseWindowIntent(),
+        if (!system.isMacOS)
+          utils.controlSingleActivator(LogicalKeyboardKey.keyW):
+              CloseWindowIntent(),
       },
       child: Actions(
         actions: {

--- a/macos/Runner/Base.lproj/MainMenu.xib
+++ b/macos/Runner/Base.lproj/MainMenu.xib
@@ -302,6 +302,12 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
                         <items>
+                            <menuItem title="Close Window" keyEquivalent="w" id="GdB-WA-Lfw">
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="KIG-BU-RLK"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="JZB-kS-Li9"/>
                             <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
                                 <connections>
                                     <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>


### PR DESCRIPTION
## 问题说明

macOS 的 `Command+W` 当前由 Flutter `Shortcuts` 处理，并直接调用 `handleBackOrExit()`。当“连接”“请求”或“日志”等页面进入搜索状态时，`SystemBackBlock` 会设置全局 `backBlock`；桌面端页面又通过 `PageView` 和 `KeepScope` 保持存活，因此切换到其他页面后，隐藏搜索页仍可能保留该拦截状态。

此时即使当前页面已经不在搜索状态，`handleBackOrExit()` 仍会因 `backBlock == true` 直接返回，表现为 `Command+W` 没有反应。

左上角关闭按钮走的是另一条路径：`onWindowClose()` 会先调用 `unBackBlock()`，因此同一状态下关闭按钮可以工作，而 `Command+W` 可能失效。macOS 原生菜单中也缺少标准的关闭窗口命令，导致快捷键完全依赖 Flutter 焦点和页面状态。

## 修改内容

### 1. 增加 macOS 原生关闭窗口命令

在 `MainMenu.xib` 的 Window 菜单中增加 `Close Window`，绑定 `Command+W`，Action 使用 AppKit 标准的 `performClose:`。

这样快捷键会模拟点击窗口关闭按钮，并进入现有的 `onWindowClose()` 流程，统一执行：

```text
Command+W
→ NSWindow.performClose
→ onWindowClose
→ unBackBlock
→ handleBackOrExit
→ 隐藏窗口
```

### 2. 避免 macOS 重复注册 Flutter 快捷键

macOS 不再通过 Flutter `Shortcuts` 注册 `Command+W`，避免原生菜单和 Flutter 同时响应，也避免快捷键继续受到 Flutter 焦点树及隐藏页面状态影响。

Windows 与 Linux 原有的 `Ctrl+W` 逻辑保持不变，Android 不受影响。

## 复现步骤

1. 打开“连接”“请求”或“日志”页面。
2. 进入搜索状态并输入任意内容。
3. 不退出搜索，直接切换到首页或代理页面。
4. 按下 `Command+W`。
5. 修改前窗口没有反应；修改后窗口正常隐藏，后台代理继续运行。

## 验证

- macOS XIB 已通过 `ibtool` 编译检查，无错误和警告。
- `flutter analyze lib/manager/hotkey_manager.dart` 通过。
- 现有 Flutter 测试全部通过。
- 使用包含本修改的自定义构建包，按照上述步骤进行实际验证，问题未再复现。

## 影响范围

本次仅修改 macOS 原生窗口菜单和 macOS 快捷键入口，不调整 `SystemBackBlock` 的跨平台返回逻辑，避免改变 Windows、Linux 和 Android 的现有行为。

关联：#68