### PR TITLE
修复：同步 macOS 托盘启停、重启内核与测速状态

### DIFF
--- a/lib/common/tray.dart
+++ b/lib/common/tray.dart
@@ -128,7 +128,9 @@ class Tray {
     final startMenuItem = MenuItem.checkbox(
       label: trayState.isStart ? appLocalizations.stop : appLocalizations.start,
       onClick: (_) async {
-        globalState.appController.updateStart();
+        final appController = globalState.appController;
+        await appController.updateStatus(!trayState.isStart);
+        await appController.updateTray();
       },
       checked: false,
     );
@@ -179,6 +181,7 @@ class Tray {
 
           subMenuItems.add(
             MenuItem.checkbox(
+              key: 'proxy-item:${proxy.name}',
               label: proxy.name,
               sublabel: _formatProxySublabel(delay),
               checked: group.getCurrentSelectedName(trayState.selectedMap[group.name] ?? '') == proxy.name,
@@ -245,7 +248,15 @@ class Tray {
       MenuItem(
         label: appLocalizations.restartCoreTitle,
         onClick: (_) async {
-          await globalState.appController.restartCore();
+          final appController = globalState.appController;
+          try {
+            await appController.restartCore();
+          } finally {
+            await appController.syncDesktopRuntimeState(
+              preferCurrentState: true,
+            );
+            await appController.updateTray();
+          }
         },
       ),
     ];

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -171,6 +171,9 @@ class AppController {
   Future<void> _updateStatus(bool isStart) async {
     if (isStart) {
       await _fastStart();
+      if (globalState.isStart && !_ref.read(runTimeProvider.notifier).isStart) {
+        _ref.read(runTimeProvider.notifier).value = 0;
+      }
     } else {
       await globalState.handleStop();
       clashCore.resetTraffic();
@@ -1427,9 +1430,8 @@ class AppController {
         ageSecretKey: ageSecretKey,
       ).update();
       if (globalState.navigatorKey.currentState?.canPop() ?? false) {
-        globalState.navigatorKey.currentState?.popUntil(
-          (route) => route.isFirst,
-        );
+        globalState.navigatorKey.currentState
+            ?.popUntil((route) => route.isFirst);
       }
       toProfiles();
       await addProfile(profile);
@@ -1489,8 +1491,9 @@ class AppController {
       }
 
       if (successCount > 0) {
-        globalState.navigatorKey.currentState
-            ?.popUntil((route) => route.isFirst);
+        globalState.navigatorKey.currentState?.popUntil(
+          (route) => route.isFirst,
+        );
         toProfiles();
       }
     } finally {

--- a/lib/views/proxies/list.dart
+++ b/lib/views/proxies/list.dart
@@ -356,11 +356,25 @@ class _GroupHeader extends ConsumerWidget {
                 onPressed: onScrollToSelected,
                 tooltip: 'Scroll to selected',
               ),
-              IconButton(
-                visualDensity: VisualDensity.compact,
-                icon: const Icon(Icons.network_ping),
-                onPressed: () => _delayTest(context),
-                tooltip: 'Delay test',
+              AnimatedBuilder(
+                animation: delayTestCoordinator,
+                builder: (_, _) {
+                  final isTestingThisGroup = delayTestCoordinator
+                      .isTestingGroup(group.name);
+                  return IconButton(
+                    visualDensity: VisualDensity.compact,
+                    icon: isTestingThisGroup
+                        ? const SizedBox.square(
+                            dimension: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.network_ping),
+                    onPressed: delayTestCoordinator.isTesting
+                        ? null
+                        : () => _delayTest(context),
+                    tooltip: appLocalizations.startTest,
+                  );
+                },
               ),
             ],
             IconButton.filledTonal(

--- a/lib/views/proxies/proxies.dart
+++ b/lib/views/proxies/proxies.dart
@@ -155,6 +155,9 @@ class _ProxiesViewState extends ConsumerState<ProxiesView> {
   Widget? _buildFAB() {
     if (!_isTab) return null;
     final isMobileView = ref.watch(isMobileViewProvider);
+    final currentGroupName = ref.watch(
+      proxiesTabControllerStateProvider.select((state) => state.b),
+    );
     return Padding(
       padding: EdgeInsets.only(
         bottom: isMobileView
@@ -162,6 +165,7 @@ class _ProxiesViewState extends ConsumerState<ProxiesView> {
             : 0,
       ),
       child: DelayTestButton(
+        groupName: currentGroupName ?? '',
         onClick: () async {
           await _proxiesTabKey.currentState?.delayTestCurrentGroup();
         },

--- a/lib/views/proxies/tab.dart
+++ b/lib/views/proxies/tab.dart
@@ -464,9 +464,14 @@ class _ProxyGroupViewState extends ConsumerState<ProxyGroupView> {
 }
 
 class DelayTestButton extends ConsumerStatefulWidget {
+  final String groupName;
   final Future Function() onClick;
 
-  const DelayTestButton({super.key, required this.onClick});
+  const DelayTestButton({
+    super.key,
+    required this.groupName,
+    required this.onClick,
+  });
 
   @override
   ConsumerState<DelayTestButton> createState() => _DelayTestButtonState();
@@ -476,23 +481,24 @@ class _DelayTestButtonState extends ConsumerState<DelayTestButton>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<double> _scale;
-  bool _isTesting = false;
+
+  bool get _isTesting => delayTestCoordinator.isTestingGroup(widget.groupName);
 
   Future<void> _healthcheck() async {
-    if (_isTesting) {
+    if (delayTestCoordinator.isTesting) {
       return;
     }
-    setState(() {
-      _isTesting = true;
-    });
-    _controller.forward();
     await widget.onClick();
-    if (mounted) {
-      setState(() {
-        _isTesting = false;
-      });
+  }
+
+  void _handleTestingChanged() {
+    if (!mounted) return;
+    if (_isTesting) {
+      _controller.forward();
+    } else {
       _controller.reverse();
     }
+    setState(() {});
   }
 
   @override
@@ -505,10 +511,21 @@ class _DelayTestButtonState extends ConsumerState<DelayTestButton>
     _scale = Tween<double>(begin: 1.0, end: 0.0).animate(
       CurvedAnimation(parent: _controller, curve: const Interval(0, 1)),
     );
+    delayTestCoordinator.addListener(_handleTestingChanged);
+    _handleTestingChanged();
+  }
+
+  @override
+  void didUpdateWidget(covariant DelayTestButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.groupName != widget.groupName) {
+      _handleTestingChanged();
+    }
   }
 
   @override
   void dispose() {
+    delayTestCoordinator.removeListener(_handleTestingChanged);
     _controller.dispose();
     super.dispose();
   }
@@ -526,7 +543,10 @@ class _DelayTestButtonState extends ConsumerState<DelayTestButton>
           children: [
             FloatingActionButton.extended(
               heroTag: null,
-              onPressed: _healthcheck,
+              onPressed:
+                  delayTestCoordinator.isTesting || widget.groupName.isEmpty
+                  ? null
+                  : _healthcheck,
               icon: Transform.scale(
                 scale: contentScale,
                 child: const Icon(Icons.network_ping),

--- a/plugins/tray_manager/macos/Classes/TrayMenu.swift
+++ b/plugins/tray_manager/macos/Classes/TrayMenu.swift
@@ -66,6 +66,10 @@ private final class PersistentTrayMenuItemView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
     func update(label: String, disabled: Bool) {
         isDisabled = disabled
         if disabled {
@@ -211,6 +215,7 @@ public class TrayMenu: NSMenu, NSMenuDelegate {
             }
 
             menuItem.tag = id
+            menuItem.representedObject = key.isEmpty ? nil : key
             menuItem.title = menuItemTitle(label, sublabel)
             menuItem.toolTip = toolTip
             menuItem.isEnabled = !disabled
@@ -285,6 +290,7 @@ public class TrayMenu: NSMenu, NSMenuDelegate {
 
         for (index, item) in items.enumerated() {
             let itemDict = item as! [String: Any]
+            let key: String = itemDict["key"] as? String ?? ""
             let type: String = itemDict["type"] as! String
             let label: String = itemDict["label"] as? String ?? ""
             let sublabel: String = itemDict["sublabel"] as? String ?? ""
@@ -292,7 +298,17 @@ public class TrayMenu: NSMenu, NSMenuDelegate {
             let checked: Bool? = itemDict["checked"] as? Bool
             let disabled: Bool = itemDict["disabled"] as? Bool ?? true
 
-            let menuItem = self.items[index]
+            let menuItem: NSMenuItem
+            if key.isEmpty {
+                menuItem = self.items[index]
+            } else {
+                guard let keyedItem = self.items.first(where: {
+                    ($0.representedObject as? String) == key
+                }) else {
+                    return
+                }
+                menuItem = keyedItem
+            }
             let expectsSeparator = type == "separator"
             guard menuItem.isSeparatorItem == expectsSeparator else {
                 return


### PR DESCRIPTION
## 背景

上游已经具备 macOS 托盘策略组和延迟测试基础能力，但托盘菜单保持展开、运行时状态刷新和菜单内容动态排序之间仍存在几处状态不同步：

- 从托盘点击“启动”后，内核已经启动，但图标与菜单仍可能保持停止状态，直到打开主窗口才刷新。
- 从“更多 → 重启内核”执行重启后，图标可能持续置灰，菜单仍显示“启动”。
- 主窗口隐藏、Bettbox 处于非活跃状态时，托盘里的“延迟测试”第一次点击可能只激活应用，不会开始测速。
- 策略组开始测速后关闭并重新打开托盘，按钮状态可能没有跟随正在执行的测速任务。
- 按延迟排序时，测速会改变节点顺序；原生菜单若按旧数组下标更新，显示出来的节点可能与点击回调绑定的节点不一致。

本 PR 只处理上述状态同步，不包含托盘速率、隐藏策略组快捷访问或点击行为设置。

## 使用位置

- macOS 菜单栏 Bettbox 图标 → “启动/停止”。
- macOS 菜单栏 Bettbox 图标 → “更多” → “重启内核”。
- macOS 菜单栏 Bettbox 图标 → 任一策略组 → “延迟测试”。
- 主窗口 → “代理” → 展开策略组 → 延迟测试。

## 主要修改

### 1. 托盘启动后立即同步运行时状态

旧代码只触发启停逻辑，没有等待结果，也没有主动刷新托盘：

```dart
globalState.appController.updateStart();
```

新代码等待启停完成，再读取最新状态重建托盘：

```dart
final appController = globalState.appController;
await appController.updateStatus(!trayState.isStart);
await appController.updateTray();
```

同时，当内核已启动但 `runTimeProvider` 尚未建立时补齐运行状态，使托盘状态不再依赖主窗口被打开后才更新。

### 2. 重启内核无论成功或失败都重新协调桌面运行状态

旧代码：

```dart
await globalState.appController.restartCore();
```

新代码：

```dart
final appController = globalState.appController;
try {
  await appController.restartCore();
} finally {
  await appController.syncDesktopRuntimeState(preferCurrentState: true);
  await appController.updateTray();
}
```

`finally` 用于保证重启路径抛出异常时也会重新读取真实运行状态，避免图标和“启动/停止”文案永久停留在中间态。

### 3. 面板测速按钮读取共享测速状态

旧实现由按钮组件维护本地 `_isTesting`。菜单关闭、页面切换或组件重建后，本地状态会丢失。

新实现通过 `delayTestCoordinator.isTestingGroup(groupName)` 获取指定策略组的真实状态，并监听协调器通知：

```dart
bool get _isTesting =>
    delayTestCoordinator.isTestingGroup(widget.groupName);
```

因此同一策略组在面板和托盘中的“测速中”状态保持一致，同时继续阻止一次批量测速未结束时重复发起请求。

### 4. 让隐藏窗口状态下的自定义测速按钮接收首次点击

延迟测试为了在菜单保持展开时展示悬停、按压和“测速中”状态，使用了自定义 `NSView`。旧实现没有覆盖 AppKit 的首次点击策略：

```swift
private final class PersistentTrayMenuItemView: NSView {
    // 仅处理 mouseDown / mouseUp
}
```

Apple 的 [`NSView.acceptsFirstMouse(for:)`](https://developer.apple.com/documentation/appkit/nsview/acceptsfirstmouse%28for%3A%29) 文档说明，默认实现返回 `false`：非活跃窗口的首次 `mouseDown` 只用于激活窗口，不会交给自定义 View。因此主窗口隐藏时，看起来像按钮没有响应；主窗口显示后应用已激活，同一按钮又能正常工作。

新实现明确允许该 View 接收 click-through：

```swift
override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
    true
}
```

修复只改变这个 macOS 原生自定义菜单项的事件接收，不会为了测速而唤醒主窗口，也不会恢复无关的后台轮询任务。

### 5. 使用稳定 key 更新已展开的原生菜单

旧逻辑按数组下标取得现有 `NSMenuItem`：

```swift
let menuItem = self.items[index]
```

当节点按延迟重新排序时，数组位置会变化，但旧菜单项的点击回调不会跟随变化。

新逻辑为代理节点写入稳定 key：

```dart
key: 'proxy-item:${proxy.name}'
```

原生层保存到 `representedObject`，刷新时优先按 key 查找对应菜单项：

```swift
menuItem.representedObject = key.isEmpty ? nil : key

let menuItem = self.items.first {
    ($0.representedObject as? String) == key
}
```

这样只更新标题、延迟和勾选状态，不替换原菜单项，显示内容与点击回调始终指向同一节点。

## 平台范围

- 原生菜单稳定 key 更新仅作用于 macOS。
- Dart 侧共享测速状态也用于代理面板，但不改变其他平台的网络、代理或 TUN 行为。

## 验证

- `flutter analyze`：通过。
- `flutter test`：9 项全部通过。
- macOS 自定义构建包实机验证：托盘启停、重启内核、关闭并重新打开菜单后的测速状态均正常。

这是关闭的 #321 拆分出的独立修复 PR。
