### PR TITLE
功能：在 macOS 菜单栏显示实时上传与下载速率

### DIFF
--- a/arb/intl_en.arb
+++ b/arb/intl_en.arb
@@ -59,6 +59,8 @@
   "alwaysShowTitleBarDesc": "Always show the title bar buttons in the top-right corner",
   "trayEnhancement": "Tray Enhancement",
   "trayEnhancementDesc": "Control proxy groups in the system tray context menu",
+  "enableTraySpeed": "Enable Tray Speed",
+  "enableTraySpeedDesc": "Show upload and download speeds next to the menu bar icon",
   "excludeChina": "Exclude China",
   "excludeChinaDesc": "Allow China QUIC traffic instead of blocking all",
   "fcmOptimization": "FCM Optimization",
@@ -654,4 +656,3 @@
   "lineWrap": "Wrap Lines",
   "showHiddenItems": "Show Hidden Items"
 }
-

--- a/arb/intl_ru.arb
+++ b/arb/intl_ru.arb
@@ -59,6 +59,8 @@
   "alwaysShowTitleBarDesc": "Всегда показывать кнопки в правом верхнем углу",
   "trayEnhancement": "Улучшение трея",
   "trayEnhancementDesc": "Управление группами прокси в контекстном меню трея",
+  "enableTraySpeed": "Показывать скорость в трее",
+  "enableTraySpeedDesc": "Показывать скорость отдачи и загрузки рядом со значком в строке меню",
   "excludeChina": "Исключить Китай",
   "excludeChinaDesc": "Разрешить QUIC-трафик Китая вместо полной блокировки",
   "fcmOptimization": "Оптимизация FCM",
@@ -657,4 +659,3 @@
   "lineWrap": "Перенос строк",
   "showHiddenItems": "Показать скрытые"
 }
-

--- a/arb/intl_zh_CN.arb
+++ b/arb/intl_zh_CN.arb
@@ -59,6 +59,8 @@
   "alwaysShowTitleBarDesc": "始终显示右上角的标题栏按钮",
   "trayEnhancement": "托盘增强",
   "trayEnhancementDesc": "在托盘区右键菜单中控制代理组",
+  "enableTraySpeed": "启用托盘速率",
+  "enableTraySpeedDesc": "在菜单栏图标右侧显示上传和下载速率",
   "excludeChina": "排除国内",
   "excludeChinaDesc": "放行中国QUIC流量而非全部禁用",
   "fcmOptimization": "FCM优化",
@@ -655,4 +657,3 @@
   "lineWrap": "自动换行",
   "showHiddenItems": "显示隐藏项"
 }
-

--- a/arb/intl_zh_TC.arb
+++ b/arb/intl_zh_TC.arb
@@ -59,6 +59,8 @@
   "alwaysShowTitleBarDesc": "始終顯示右上角的標題欄按鈕",
   "trayEnhancement": "托盤增強",
   "trayEnhancementDesc": "在托盤區右鍵選單中控制代理組",
+  "enableTraySpeed": "啟用托盤速率",
+  "enableTraySpeedDesc": "在選單列圖示右側顯示上傳和下載速率",
   "excludeChina": "排除國內",
   "excludeChinaDesc": "放行中國QUIC流量而非全部禁用",
   "fcmOptimization": "FCM 優化",
@@ -655,4 +657,3 @@
   "lineWrap": "自動換行",
   "showHiddenItems": "顯示隱藏項"
 }
-

--- a/lib/common/tray.dart
+++ b/lib/common/tray.dart
@@ -26,8 +26,6 @@ class Tray {
   int _loadingFrame = 0;
   final List<String> _loadingFrames = ['.', '..', '...'];
 
-
-
   Tray() {
     delayTestCoordinator.addListener(_handleDelayTestStateChanged);
   }
@@ -36,6 +34,14 @@ class Tray {
     if (system.isAndroid) return;
     unawaited(globalState.appController.updateTray(false, true));
   }
+
+  bool _traySpeedEnabled = false;
+  bool _trayTrafficActive = false;
+  bool _isSpeedTitleVisible = false;
+  Traffic _lastTraffic = Traffic();
+  int? _lastDisplayedUpload;
+  int? _lastDisplayedDownload;
+  bool? _lastDisplayedActive;
 
   void dispose() {
     delayTestCoordinator.removeListener(_handleDelayTestStateChanged);
@@ -52,6 +58,10 @@ class Tray {
     }
     if (force) {
       await trayManager.destroy();
+      _isSpeedTitleVisible = false;
+      _lastDisplayedUpload = null;
+      _lastDisplayedDownload = null;
+      _lastDisplayedActive = null;
     }
     await trayManager.setIcon(
       utils.getTrayIconPath(
@@ -64,6 +74,9 @@ class Tray {
       ),
       isTemplate: system.isMacOS,
     );
+    if (system.isMacOS) {
+      await trayManager.setActive(isStart);
+    }
     if (!Platform.isLinux) {
       await trayManager.setToolTip(appName);
     }
@@ -110,12 +123,18 @@ class Tray {
     _isUpdating = true;
 
     try {
+      _traySpeedEnabled = trayState.enableTraySpeed;
+      _trayTrafficActive =
+          trayState.isStart && (trayState.systemProxy || trayState.tunEnable);
       if (!silent && !Platform.isLinux) {
         await _updateSystemTray(
           brightness: trayState.brightness,
-          isStart: trayState.isStart,
+          isStart: _trayTrafficActive,
           force: focus,
         );
+      }
+      if (system.isMacOS) {
+        await _syncSpeedTitle(isStart: trayState.isStart);
       }
     List<MenuItem> menuItems = [];
     final showMenuItem = MenuItem(
@@ -307,6 +326,53 @@ class Tray {
         );
       }
     }
+  }
+
+  Future<void> updateSpeed(Traffic traffic) async {
+    _lastTraffic = traffic;
+    if (!system.isMacOS || !_traySpeedEnabled) {
+      return;
+    }
+    await _setSpeedTitle(traffic);
+  }
+
+  Future<void> _syncSpeedTitle({required bool isStart}) async {
+    if (!_traySpeedEnabled) {
+      if (!_isSpeedTitleVisible) {
+        return;
+      }
+      await trayManager.clearSpeedTitle();
+      _isSpeedTitleVisible = false;
+      _lastDisplayedUpload = null;
+      _lastDisplayedDownload = null;
+      _lastDisplayedActive = null;
+      return;
+    }
+
+    if (!isStart) {
+      _lastTraffic = Traffic();
+    }
+    await _setSpeedTitle(_lastTraffic);
+  }
+
+  Future<void> _setSpeedTitle(Traffic traffic) async {
+    final upload = traffic.up.value;
+    final download = traffic.down.value;
+    if (_isSpeedTitleVisible &&
+        _lastDisplayedUpload == upload &&
+        _lastDisplayedDownload == download &&
+        _lastDisplayedActive == _trayTrafficActive) {
+      return;
+    }
+    await trayManager.setSpeedTitle(
+      upload: upload,
+      download: download,
+      active: _trayTrafficActive,
+    );
+    _isSpeedTitleVisible = true;
+    _lastDisplayedUpload = upload;
+    _lastDisplayedDownload = download;
+    _lastDisplayedActive = _trayTrafficActive;
   }
 
   MenuItem _buildCopyEnvSubmenu(int port) {

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -404,8 +404,12 @@ class AppController {
     final networkSpeedNotification =
         system.isAndroid &&
         _ref.read(vpnSettingProvider).networkSpeedNotification;
+    final enableTraySpeed =
+        system.isMacOS && _ref.read(vpnSettingProvider).enableTraySpeed;
 
-    if (!shouldUpdateDashboard && !networkSpeedNotification) {
+    if (!shouldUpdateDashboard &&
+        !networkSpeedNotification &&
+        !enableTraySpeed) {
       return;
     }
 
@@ -419,6 +423,10 @@ class AppController {
 
     if (shouldUpdateDashboard) {
       _ref.read(trafficsProvider.notifier).addTraffic(traffic);
+    }
+
+    if (enableTraySpeed) {
+      await tray.updateSpeed(traffic);
     }
 
     if (networkSpeedNotification) {

--- a/lib/l10n/intl/messages_en.dart
+++ b/lib/l10n/intl/messages_en.dart
@@ -398,6 +398,12 @@ class MessageLookup extends MessageLookupByLibrary {
       "Upload crash logs when needed",
     ),
     "enableOverride": MessageLookupByLibrary.simpleMessage("Enable Override"),
+    "enableTraySpeed": MessageLookupByLibrary.simpleMessage(
+      "Enable Tray Speed",
+    ),
+    "enableTraySpeedDesc": MessageLookupByLibrary.simpleMessage(
+      "Show upload and download speeds next to the menu bar icon",
+    ),
     "endpointIndependentNat": MessageLookupByLibrary.simpleMessage(
       "NAT Enhancement",
     ),

--- a/lib/l10n/intl/messages_ru.dart
+++ b/lib/l10n/intl/messages_ru.dart
@@ -401,6 +401,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "enableOverride": MessageLookupByLibrary.simpleMessage(
       "Включить переопределение",
     ),
+    "enableTraySpeed": MessageLookupByLibrary.simpleMessage(
+      "Показывать скорость в трее",
+    ),
+    "enableTraySpeedDesc": MessageLookupByLibrary.simpleMessage(
+      "Показывать скорость отдачи и загрузки рядом со значком в строке меню",
+    ),
     "endpointIndependentNat": MessageLookupByLibrary.simpleMessage(
       "Улучшенный NAT",
     ),

--- a/lib/l10n/intl/messages_zh_CN.dart
+++ b/lib/l10n/intl/messages_zh_CN.dart
@@ -275,6 +275,10 @@ class MessageLookup extends MessageLookupByLibrary {
       "必要时上传应用崩溃日志",
     ),
     "enableOverride": MessageLookupByLibrary.simpleMessage("启用覆写"),
+    "enableTraySpeed": MessageLookupByLibrary.simpleMessage("启用托盘速率"),
+    "enableTraySpeedDesc": MessageLookupByLibrary.simpleMessage(
+      "在菜单栏图标右侧显示上传和下载速率",
+    ),
     "endpointIndependentNat": MessageLookupByLibrary.simpleMessage("NAT增强"),
     "endpointIndependentNatConfirmDesc": MessageLookupByLibrary.simpleMessage(
       "启用 Endpoint-Independent NAT 功能，性能可能会略有下降，此功能仅建议您在必要且熟悉的情况下开启",

--- a/lib/l10n/intl/messages_zh_TC.dart
+++ b/lib/l10n/intl/messages_zh_TC.dart
@@ -281,6 +281,10 @@ class MessageLookup extends MessageLookupByLibrary {
       "必要時上傳應用崩潰日誌",
     ),
     "enableOverride": MessageLookupByLibrary.simpleMessage("啟用覆寫"),
+    "enableTraySpeed": MessageLookupByLibrary.simpleMessage("啟用托盤速率"),
+    "enableTraySpeedDesc": MessageLookupByLibrary.simpleMessage(
+      "在選單列圖示右側顯示上傳和下載速率",
+    ),
     "endpointIndependentNat": MessageLookupByLibrary.simpleMessage("NAT 增強"),
     "endpointIndependentNatConfirmDesc": MessageLookupByLibrary.simpleMessage(
       "啟用 Endpoint-Independent NAT 功能，性能可能會略有下降，此功能僅建議您在必要且熟悉的情況下開啟",

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -529,6 +529,26 @@ class AppLocalizations {
     );
   }
 
+  /// `Enable Tray Speed`
+  String get enableTraySpeed {
+    return Intl.message(
+      'Enable Tray Speed',
+      name: 'enableTraySpeed',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Show upload and download speeds next to the menu bar icon`
+  String get enableTraySpeedDesc {
+    return Intl.message(
+      'Show upload and download speeds next to the menu bar icon',
+      name: 'enableTraySpeedDesc',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Exclude China`
   String get excludeChina {
     return Intl.message(

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -217,6 +217,7 @@ abstract class VpnProps with _$VpnProps {
     @Default(false) bool networkSpeedNotification,
     @Default(false) bool excludeChina,
     @Default(false) bool trayEnhancement,
+    @Default(false) bool enableTraySpeed,
     @Default(true) bool alwaysShowTitleBar,
     @Default(true) bool quickResponse,
     @Default(defaultAccessControl) AccessControl accessControl,

--- a/lib/models/generated/config.freezed.dart
+++ b/lib/models/generated/config.freezed.dart
@@ -930,7 +930,7 @@ as bool,
 /// @nodoc
 mixin _$VpnProps {
 
- bool get enable; bool get systemProxy; bool get allowBypass; bool get bypassPrivateRoute; bool get dozeSuspend; bool get smartAutoStop; String get smartAutoStopNetworks; bool get storeFix; bool get networkFix; bool get disableQuic; bool get networkSpeedNotification; bool get excludeChina; bool get trayEnhancement; bool get alwaysShowTitleBar; bool get quickResponse; AccessControl get accessControl;
+ bool get enable; bool get systemProxy; bool get allowBypass; bool get bypassPrivateRoute; bool get dozeSuspend; bool get smartAutoStop; String get smartAutoStopNetworks; bool get storeFix; bool get networkFix; bool get disableQuic; bool get networkSpeedNotification; bool get excludeChina; bool get trayEnhancement; bool get enableTraySpeed; bool get alwaysShowTitleBar; bool get quickResponse; AccessControl get accessControl;
 /// Create a copy of VpnProps
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -943,16 +943,16 @@ $VpnPropsCopyWith<VpnProps> get copyWith => _$VpnPropsCopyWithImpl<VpnProps>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is VpnProps&&(identical(other.enable, enable) || other.enable == enable)&&(identical(other.systemProxy, systemProxy) || other.systemProxy == systemProxy)&&(identical(other.allowBypass, allowBypass) || other.allowBypass == allowBypass)&&(identical(other.bypassPrivateRoute, bypassPrivateRoute) || other.bypassPrivateRoute == bypassPrivateRoute)&&(identical(other.dozeSuspend, dozeSuspend) || other.dozeSuspend == dozeSuspend)&&(identical(other.smartAutoStop, smartAutoStop) || other.smartAutoStop == smartAutoStop)&&(identical(other.smartAutoStopNetworks, smartAutoStopNetworks) || other.smartAutoStopNetworks == smartAutoStopNetworks)&&(identical(other.storeFix, storeFix) || other.storeFix == storeFix)&&(identical(other.networkFix, networkFix) || other.networkFix == networkFix)&&(identical(other.disableQuic, disableQuic) || other.disableQuic == disableQuic)&&(identical(other.networkSpeedNotification, networkSpeedNotification) || other.networkSpeedNotification == networkSpeedNotification)&&(identical(other.excludeChina, excludeChina) || other.excludeChina == excludeChina)&&(identical(other.trayEnhancement, trayEnhancement) || other.trayEnhancement == trayEnhancement)&&(identical(other.alwaysShowTitleBar, alwaysShowTitleBar) || other.alwaysShowTitleBar == alwaysShowTitleBar)&&(identical(other.quickResponse, quickResponse) || other.quickResponse == quickResponse)&&(identical(other.accessControl, accessControl) || other.accessControl == accessControl));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VpnProps&&(identical(other.enable, enable) || other.enable == enable)&&(identical(other.systemProxy, systemProxy) || other.systemProxy == systemProxy)&&(identical(other.allowBypass, allowBypass) || other.allowBypass == allowBypass)&&(identical(other.bypassPrivateRoute, bypassPrivateRoute) || other.bypassPrivateRoute == bypassPrivateRoute)&&(identical(other.dozeSuspend, dozeSuspend) || other.dozeSuspend == dozeSuspend)&&(identical(other.smartAutoStop, smartAutoStop) || other.smartAutoStop == smartAutoStop)&&(identical(other.smartAutoStopNetworks, smartAutoStopNetworks) || other.smartAutoStopNetworks == smartAutoStopNetworks)&&(identical(other.storeFix, storeFix) || other.storeFix == storeFix)&&(identical(other.networkFix, networkFix) || other.networkFix == networkFix)&&(identical(other.disableQuic, disableQuic) || other.disableQuic == disableQuic)&&(identical(other.networkSpeedNotification, networkSpeedNotification) || other.networkSpeedNotification == networkSpeedNotification)&&(identical(other.excludeChina, excludeChina) || other.excludeChina == excludeChina)&&(identical(other.trayEnhancement, trayEnhancement) || other.trayEnhancement == trayEnhancement)&&(identical(other.enableTraySpeed, enableTraySpeed) || other.enableTraySpeed == enableTraySpeed)&&(identical(other.alwaysShowTitleBar, alwaysShowTitleBar) || other.alwaysShowTitleBar == alwaysShowTitleBar)&&(identical(other.quickResponse, quickResponse) || other.quickResponse == quickResponse)&&(identical(other.accessControl, accessControl) || other.accessControl == accessControl));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,enable,systemProxy,allowBypass,bypassPrivateRoute,dozeSuspend,smartAutoStop,smartAutoStopNetworks,storeFix,networkFix,disableQuic,networkSpeedNotification,excludeChina,trayEnhancement,alwaysShowTitleBar,quickResponse,accessControl);
+int get hashCode => Object.hash(runtimeType,enable,systemProxy,allowBypass,bypassPrivateRoute,dozeSuspend,smartAutoStop,smartAutoStopNetworks,storeFix,networkFix,disableQuic,networkSpeedNotification,excludeChina,trayEnhancement,enableTraySpeed,alwaysShowTitleBar,quickResponse,accessControl);
 
 @override
 String toString() {
-  return 'VpnProps(enable: $enable, systemProxy: $systemProxy, allowBypass: $allowBypass, bypassPrivateRoute: $bypassPrivateRoute, dozeSuspend: $dozeSuspend, smartAutoStop: $smartAutoStop, smartAutoStopNetworks: $smartAutoStopNetworks, storeFix: $storeFix, networkFix: $networkFix, disableQuic: $disableQuic, networkSpeedNotification: $networkSpeedNotification, excludeChina: $excludeChina, trayEnhancement: $trayEnhancement, alwaysShowTitleBar: $alwaysShowTitleBar, quickResponse: $quickResponse, accessControl: $accessControl)';
+  return 'VpnProps(enable: $enable, systemProxy: $systemProxy, allowBypass: $allowBypass, bypassPrivateRoute: $bypassPrivateRoute, dozeSuspend: $dozeSuspend, smartAutoStop: $smartAutoStop, smartAutoStopNetworks: $smartAutoStopNetworks, storeFix: $storeFix, networkFix: $networkFix, disableQuic: $disableQuic, networkSpeedNotification: $networkSpeedNotification, excludeChina: $excludeChina, trayEnhancement: $trayEnhancement, enableTraySpeed: $enableTraySpeed, alwaysShowTitleBar: $alwaysShowTitleBar, quickResponse: $quickResponse, accessControl: $accessControl)';
 }
 
 
@@ -963,7 +963,7 @@ abstract mixin class $VpnPropsCopyWith<$Res>  {
   factory $VpnPropsCopyWith(VpnProps value, $Res Function(VpnProps) _then) = _$VpnPropsCopyWithImpl;
 @useResult
 $Res call({
- bool enable, bool systemProxy, bool allowBypass, bool bypassPrivateRoute, bool dozeSuspend, bool smartAutoStop, String smartAutoStopNetworks, bool storeFix, bool networkFix, bool disableQuic, bool networkSpeedNotification, bool excludeChina, bool trayEnhancement, bool alwaysShowTitleBar, bool quickResponse, AccessControl accessControl
+ bool enable, bool systemProxy, bool allowBypass, bool bypassPrivateRoute, bool dozeSuspend, bool smartAutoStop, String smartAutoStopNetworks, bool storeFix, bool networkFix, bool disableQuic, bool networkSpeedNotification, bool excludeChina, bool trayEnhancement, bool enableTraySpeed, bool alwaysShowTitleBar, bool quickResponse, AccessControl accessControl
 });
 
 
@@ -980,7 +980,7 @@ class _$VpnPropsCopyWithImpl<$Res>
 
 /// Create a copy of VpnProps
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? enable = null,Object? systemProxy = null,Object? allowBypass = null,Object? bypassPrivateRoute = null,Object? dozeSuspend = null,Object? smartAutoStop = null,Object? smartAutoStopNetworks = null,Object? storeFix = null,Object? networkFix = null,Object? disableQuic = null,Object? networkSpeedNotification = null,Object? excludeChina = null,Object? trayEnhancement = null,Object? alwaysShowTitleBar = null,Object? quickResponse = null,Object? accessControl = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? enable = null,Object? systemProxy = null,Object? allowBypass = null,Object? bypassPrivateRoute = null,Object? dozeSuspend = null,Object? smartAutoStop = null,Object? smartAutoStopNetworks = null,Object? storeFix = null,Object? networkFix = null,Object? disableQuic = null,Object? networkSpeedNotification = null,Object? excludeChina = null,Object? trayEnhancement = null,Object? enableTraySpeed = null,Object? alwaysShowTitleBar = null,Object? quickResponse = null,Object? accessControl = null,}) {
   return _then(_self.copyWith(
 enable: null == enable ? _self.enable : enable // ignore: cast_nullable_to_non_nullable
 as bool,systemProxy: null == systemProxy ? _self.systemProxy : systemProxy // ignore: cast_nullable_to_non_nullable
@@ -995,6 +995,7 @@ as bool,disableQuic: null == disableQuic ? _self.disableQuic : disableQuic // ig
 as bool,networkSpeedNotification: null == networkSpeedNotification ? _self.networkSpeedNotification : networkSpeedNotification // ignore: cast_nullable_to_non_nullable
 as bool,excludeChina: null == excludeChina ? _self.excludeChina : excludeChina // ignore: cast_nullable_to_non_nullable
 as bool,trayEnhancement: null == trayEnhancement ? _self.trayEnhancement : trayEnhancement // ignore: cast_nullable_to_non_nullable
+as bool,enableTraySpeed: null == enableTraySpeed ? _self.enableTraySpeed : enableTraySpeed // ignore: cast_nullable_to_non_nullable
 as bool,alwaysShowTitleBar: null == alwaysShowTitleBar ? _self.alwaysShowTitleBar : alwaysShowTitleBar // ignore: cast_nullable_to_non_nullable
 as bool,quickResponse: null == quickResponse ? _self.quickResponse : quickResponse // ignore: cast_nullable_to_non_nullable
 as bool,accessControl: null == accessControl ? _self.accessControl : accessControl // ignore: cast_nullable_to_non_nullable
@@ -1092,10 +1093,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool enable,  bool systemProxy,  bool allowBypass,  bool bypassPrivateRoute,  bool dozeSuspend,  bool smartAutoStop,  String smartAutoStopNetworks,  bool storeFix,  bool networkFix,  bool disableQuic,  bool networkSpeedNotification,  bool excludeChina,  bool trayEnhancement,  bool alwaysShowTitleBar,  bool quickResponse,  AccessControl accessControl)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool enable,  bool systemProxy,  bool allowBypass,  bool bypassPrivateRoute,  bool dozeSuspend,  bool smartAutoStop,  String smartAutoStopNetworks,  bool storeFix,  bool networkFix,  bool disableQuic,  bool networkSpeedNotification,  bool excludeChina,  bool trayEnhancement,  bool enableTraySpeed,  bool alwaysShowTitleBar,  bool quickResponse,  AccessControl accessControl)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _VpnProps() when $default != null:
-return $default(_that.enable,_that.systemProxy,_that.allowBypass,_that.bypassPrivateRoute,_that.dozeSuspend,_that.smartAutoStop,_that.smartAutoStopNetworks,_that.storeFix,_that.networkFix,_that.disableQuic,_that.networkSpeedNotification,_that.excludeChina,_that.trayEnhancement,_that.alwaysShowTitleBar,_that.quickResponse,_that.accessControl);case _:
+return $default(_that.enable,_that.systemProxy,_that.allowBypass,_that.bypassPrivateRoute,_that.dozeSuspend,_that.smartAutoStop,_that.smartAutoStopNetworks,_that.storeFix,_that.networkFix,_that.disableQuic,_that.networkSpeedNotification,_that.excludeChina,_that.trayEnhancement,_that.enableTraySpeed,_that.alwaysShowTitleBar,_that.quickResponse,_that.accessControl);case _:
   return orElse();
 
 }
@@ -1113,10 +1114,10 @@ return $default(_that.enable,_that.systemProxy,_that.allowBypass,_that.bypassPri
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool enable,  bool systemProxy,  bool allowBypass,  bool bypassPrivateRoute,  bool dozeSuspend,  bool smartAutoStop,  String smartAutoStopNetworks,  bool storeFix,  bool networkFix,  bool disableQuic,  bool networkSpeedNotification,  bool excludeChina,  bool trayEnhancement,  bool alwaysShowTitleBar,  bool quickResponse,  AccessControl accessControl)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool enable,  bool systemProxy,  bool allowBypass,  bool bypassPrivateRoute,  bool dozeSuspend,  bool smartAutoStop,  String smartAutoStopNetworks,  bool storeFix,  bool networkFix,  bool disableQuic,  bool networkSpeedNotification,  bool excludeChina,  bool trayEnhancement,  bool enableTraySpeed,  bool alwaysShowTitleBar,  bool quickResponse,  AccessControl accessControl)  $default,) {final _that = this;
 switch (_that) {
 case _VpnProps():
-return $default(_that.enable,_that.systemProxy,_that.allowBypass,_that.bypassPrivateRoute,_that.dozeSuspend,_that.smartAutoStop,_that.smartAutoStopNetworks,_that.storeFix,_that.networkFix,_that.disableQuic,_that.networkSpeedNotification,_that.excludeChina,_that.trayEnhancement,_that.alwaysShowTitleBar,_that.quickResponse,_that.accessControl);case _:
+return $default(_that.enable,_that.systemProxy,_that.allowBypass,_that.bypassPrivateRoute,_that.dozeSuspend,_that.smartAutoStop,_that.smartAutoStopNetworks,_that.storeFix,_that.networkFix,_that.disableQuic,_that.networkSpeedNotification,_that.excludeChina,_that.trayEnhancement,_that.enableTraySpeed,_that.alwaysShowTitleBar,_that.quickResponse,_that.accessControl);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -1133,10 +1134,10 @@ return $default(_that.enable,_that.systemProxy,_that.allowBypass,_that.bypassPri
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool enable,  bool systemProxy,  bool allowBypass,  bool bypassPrivateRoute,  bool dozeSuspend,  bool smartAutoStop,  String smartAutoStopNetworks,  bool storeFix,  bool networkFix,  bool disableQuic,  bool networkSpeedNotification,  bool excludeChina,  bool trayEnhancement,  bool alwaysShowTitleBar,  bool quickResponse,  AccessControl accessControl)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool enable,  bool systemProxy,  bool allowBypass,  bool bypassPrivateRoute,  bool dozeSuspend,  bool smartAutoStop,  String smartAutoStopNetworks,  bool storeFix,  bool networkFix,  bool disableQuic,  bool networkSpeedNotification,  bool excludeChina,  bool trayEnhancement,  bool enableTraySpeed,  bool alwaysShowTitleBar,  bool quickResponse,  AccessControl accessControl)?  $default,) {final _that = this;
 switch (_that) {
 case _VpnProps() when $default != null:
-return $default(_that.enable,_that.systemProxy,_that.allowBypass,_that.bypassPrivateRoute,_that.dozeSuspend,_that.smartAutoStop,_that.smartAutoStopNetworks,_that.storeFix,_that.networkFix,_that.disableQuic,_that.networkSpeedNotification,_that.excludeChina,_that.trayEnhancement,_that.alwaysShowTitleBar,_that.quickResponse,_that.accessControl);case _:
+return $default(_that.enable,_that.systemProxy,_that.allowBypass,_that.bypassPrivateRoute,_that.dozeSuspend,_that.smartAutoStop,_that.smartAutoStopNetworks,_that.storeFix,_that.networkFix,_that.disableQuic,_that.networkSpeedNotification,_that.excludeChina,_that.trayEnhancement,_that.enableTraySpeed,_that.alwaysShowTitleBar,_that.quickResponse,_that.accessControl);case _:
   return null;
 
 }
@@ -1148,7 +1149,7 @@ return $default(_that.enable,_that.systemProxy,_that.allowBypass,_that.bypassPri
 @JsonSerializable()
 
 class _VpnProps implements VpnProps {
-  const _VpnProps({this.enable = true, this.systemProxy = false, this.allowBypass = false, this.bypassPrivateRoute = true, this.dozeSuspend = true, this.smartAutoStop = false, this.smartAutoStopNetworks = '', this.storeFix = false, this.networkFix = false, this.disableQuic = false, this.networkSpeedNotification = false, this.excludeChina = false, this.trayEnhancement = false, this.alwaysShowTitleBar = true, this.quickResponse = true, this.accessControl = defaultAccessControl});
+  const _VpnProps({this.enable = true, this.systemProxy = false, this.allowBypass = false, this.bypassPrivateRoute = true, this.dozeSuspend = true, this.smartAutoStop = false, this.smartAutoStopNetworks = '', this.storeFix = false, this.networkFix = false, this.disableQuic = false, this.networkSpeedNotification = false, this.excludeChina = false, this.trayEnhancement = false, this.enableTraySpeed = false, this.alwaysShowTitleBar = true, this.quickResponse = true, this.accessControl = defaultAccessControl});
   factory _VpnProps.fromJson(Map<String, dynamic> json) => _$VpnPropsFromJson(json);
 
 @override@JsonKey() final  bool enable;
@@ -1164,6 +1165,7 @@ class _VpnProps implements VpnProps {
 @override@JsonKey() final  bool networkSpeedNotification;
 @override@JsonKey() final  bool excludeChina;
 @override@JsonKey() final  bool trayEnhancement;
+@override@JsonKey() final  bool enableTraySpeed;
 @override@JsonKey() final  bool alwaysShowTitleBar;
 @override@JsonKey() final  bool quickResponse;
 @override@JsonKey() final  AccessControl accessControl;
@@ -1181,16 +1183,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VpnProps&&(identical(other.enable, enable) || other.enable == enable)&&(identical(other.systemProxy, systemProxy) || other.systemProxy == systemProxy)&&(identical(other.allowBypass, allowBypass) || other.allowBypass == allowBypass)&&(identical(other.bypassPrivateRoute, bypassPrivateRoute) || other.bypassPrivateRoute == bypassPrivateRoute)&&(identical(other.dozeSuspend, dozeSuspend) || other.dozeSuspend == dozeSuspend)&&(identical(other.smartAutoStop, smartAutoStop) || other.smartAutoStop == smartAutoStop)&&(identical(other.smartAutoStopNetworks, smartAutoStopNetworks) || other.smartAutoStopNetworks == smartAutoStopNetworks)&&(identical(other.storeFix, storeFix) || other.storeFix == storeFix)&&(identical(other.networkFix, networkFix) || other.networkFix == networkFix)&&(identical(other.disableQuic, disableQuic) || other.disableQuic == disableQuic)&&(identical(other.networkSpeedNotification, networkSpeedNotification) || other.networkSpeedNotification == networkSpeedNotification)&&(identical(other.excludeChina, excludeChina) || other.excludeChina == excludeChina)&&(identical(other.trayEnhancement, trayEnhancement) || other.trayEnhancement == trayEnhancement)&&(identical(other.alwaysShowTitleBar, alwaysShowTitleBar) || other.alwaysShowTitleBar == alwaysShowTitleBar)&&(identical(other.quickResponse, quickResponse) || other.quickResponse == quickResponse)&&(identical(other.accessControl, accessControl) || other.accessControl == accessControl));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VpnProps&&(identical(other.enable, enable) || other.enable == enable)&&(identical(other.systemProxy, systemProxy) || other.systemProxy == systemProxy)&&(identical(other.allowBypass, allowBypass) || other.allowBypass == allowBypass)&&(identical(other.bypassPrivateRoute, bypassPrivateRoute) || other.bypassPrivateRoute == bypassPrivateRoute)&&(identical(other.dozeSuspend, dozeSuspend) || other.dozeSuspend == dozeSuspend)&&(identical(other.smartAutoStop, smartAutoStop) || other.smartAutoStop == smartAutoStop)&&(identical(other.smartAutoStopNetworks, smartAutoStopNetworks) || other.smartAutoStopNetworks == smartAutoStopNetworks)&&(identical(other.storeFix, storeFix) || other.storeFix == storeFix)&&(identical(other.networkFix, networkFix) || other.networkFix == networkFix)&&(identical(other.disableQuic, disableQuic) || other.disableQuic == disableQuic)&&(identical(other.networkSpeedNotification, networkSpeedNotification) || other.networkSpeedNotification == networkSpeedNotification)&&(identical(other.excludeChina, excludeChina) || other.excludeChina == excludeChina)&&(identical(other.trayEnhancement, trayEnhancement) || other.trayEnhancement == trayEnhancement)&&(identical(other.enableTraySpeed, enableTraySpeed) || other.enableTraySpeed == enableTraySpeed)&&(identical(other.alwaysShowTitleBar, alwaysShowTitleBar) || other.alwaysShowTitleBar == alwaysShowTitleBar)&&(identical(other.quickResponse, quickResponse) || other.quickResponse == quickResponse)&&(identical(other.accessControl, accessControl) || other.accessControl == accessControl));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,enable,systemProxy,allowBypass,bypassPrivateRoute,dozeSuspend,smartAutoStop,smartAutoStopNetworks,storeFix,networkFix,disableQuic,networkSpeedNotification,excludeChina,trayEnhancement,alwaysShowTitleBar,quickResponse,accessControl);
+int get hashCode => Object.hash(runtimeType,enable,systemProxy,allowBypass,bypassPrivateRoute,dozeSuspend,smartAutoStop,smartAutoStopNetworks,storeFix,networkFix,disableQuic,networkSpeedNotification,excludeChina,trayEnhancement,enableTraySpeed,alwaysShowTitleBar,quickResponse,accessControl);
 
 @override
 String toString() {
-  return 'VpnProps(enable: $enable, systemProxy: $systemProxy, allowBypass: $allowBypass, bypassPrivateRoute: $bypassPrivateRoute, dozeSuspend: $dozeSuspend, smartAutoStop: $smartAutoStop, smartAutoStopNetworks: $smartAutoStopNetworks, storeFix: $storeFix, networkFix: $networkFix, disableQuic: $disableQuic, networkSpeedNotification: $networkSpeedNotification, excludeChina: $excludeChina, trayEnhancement: $trayEnhancement, alwaysShowTitleBar: $alwaysShowTitleBar, quickResponse: $quickResponse, accessControl: $accessControl)';
+  return 'VpnProps(enable: $enable, systemProxy: $systemProxy, allowBypass: $allowBypass, bypassPrivateRoute: $bypassPrivateRoute, dozeSuspend: $dozeSuspend, smartAutoStop: $smartAutoStop, smartAutoStopNetworks: $smartAutoStopNetworks, storeFix: $storeFix, networkFix: $networkFix, disableQuic: $disableQuic, networkSpeedNotification: $networkSpeedNotification, excludeChina: $excludeChina, trayEnhancement: $trayEnhancement, enableTraySpeed: $enableTraySpeed, alwaysShowTitleBar: $alwaysShowTitleBar, quickResponse: $quickResponse, accessControl: $accessControl)';
 }
 
 
@@ -1201,7 +1203,7 @@ abstract mixin class _$VpnPropsCopyWith<$Res> implements $VpnPropsCopyWith<$Res>
   factory _$VpnPropsCopyWith(_VpnProps value, $Res Function(_VpnProps) _then) = __$VpnPropsCopyWithImpl;
 @override @useResult
 $Res call({
- bool enable, bool systemProxy, bool allowBypass, bool bypassPrivateRoute, bool dozeSuspend, bool smartAutoStop, String smartAutoStopNetworks, bool storeFix, bool networkFix, bool disableQuic, bool networkSpeedNotification, bool excludeChina, bool trayEnhancement, bool alwaysShowTitleBar, bool quickResponse, AccessControl accessControl
+ bool enable, bool systemProxy, bool allowBypass, bool bypassPrivateRoute, bool dozeSuspend, bool smartAutoStop, String smartAutoStopNetworks, bool storeFix, bool networkFix, bool disableQuic, bool networkSpeedNotification, bool excludeChina, bool trayEnhancement, bool enableTraySpeed, bool alwaysShowTitleBar, bool quickResponse, AccessControl accessControl
 });
 
 
@@ -1218,7 +1220,7 @@ class __$VpnPropsCopyWithImpl<$Res>
 
 /// Create a copy of VpnProps
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? enable = null,Object? systemProxy = null,Object? allowBypass = null,Object? bypassPrivateRoute = null,Object? dozeSuspend = null,Object? smartAutoStop = null,Object? smartAutoStopNetworks = null,Object? storeFix = null,Object? networkFix = null,Object? disableQuic = null,Object? networkSpeedNotification = null,Object? excludeChina = null,Object? trayEnhancement = null,Object? alwaysShowTitleBar = null,Object? quickResponse = null,Object? accessControl = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? enable = null,Object? systemProxy = null,Object? allowBypass = null,Object? bypassPrivateRoute = null,Object? dozeSuspend = null,Object? smartAutoStop = null,Object? smartAutoStopNetworks = null,Object? storeFix = null,Object? networkFix = null,Object? disableQuic = null,Object? networkSpeedNotification = null,Object? excludeChina = null,Object? trayEnhancement = null,Object? enableTraySpeed = null,Object? alwaysShowTitleBar = null,Object? quickResponse = null,Object? accessControl = null,}) {
   return _then(_VpnProps(
 enable: null == enable ? _self.enable : enable // ignore: cast_nullable_to_non_nullable
 as bool,systemProxy: null == systemProxy ? _self.systemProxy : systemProxy // ignore: cast_nullable_to_non_nullable
@@ -1233,6 +1235,7 @@ as bool,disableQuic: null == disableQuic ? _self.disableQuic : disableQuic // ig
 as bool,networkSpeedNotification: null == networkSpeedNotification ? _self.networkSpeedNotification : networkSpeedNotification // ignore: cast_nullable_to_non_nullable
 as bool,excludeChina: null == excludeChina ? _self.excludeChina : excludeChina // ignore: cast_nullable_to_non_nullable
 as bool,trayEnhancement: null == trayEnhancement ? _self.trayEnhancement : trayEnhancement // ignore: cast_nullable_to_non_nullable
+as bool,enableTraySpeed: null == enableTraySpeed ? _self.enableTraySpeed : enableTraySpeed // ignore: cast_nullable_to_non_nullable
 as bool,alwaysShowTitleBar: null == alwaysShowTitleBar ? _self.alwaysShowTitleBar : alwaysShowTitleBar // ignore: cast_nullable_to_non_nullable
 as bool,quickResponse: null == quickResponse ? _self.quickResponse : quickResponse // ignore: cast_nullable_to_non_nullable
 as bool,accessControl: null == accessControl ? _self.accessControl : accessControl // ignore: cast_nullable_to_non_nullable

--- a/lib/models/generated/config.g.dart
+++ b/lib/models/generated/config.g.dart
@@ -187,6 +187,7 @@ _VpnProps _$VpnPropsFromJson(Map<String, dynamic> json) => _VpnProps(
   networkSpeedNotification: json['networkSpeedNotification'] as bool? ?? false,
   excludeChina: json['excludeChina'] as bool? ?? false,
   trayEnhancement: json['trayEnhancement'] as bool? ?? false,
+  enableTraySpeed: json['enableTraySpeed'] as bool? ?? false,
   alwaysShowTitleBar: json['alwaysShowTitleBar'] as bool? ?? true,
   quickResponse: json['quickResponse'] as bool? ?? true,
   accessControl: json['accessControl'] == null
@@ -208,6 +209,7 @@ Map<String, dynamic> _$VpnPropsToJson(_VpnProps instance) => <String, dynamic>{
   'networkSpeedNotification': instance.networkSpeedNotification,
   'excludeChina': instance.excludeChina,
   'trayEnhancement': instance.trayEnhancement,
+  'enableTraySpeed': instance.enableTraySpeed,
   'alwaysShowTitleBar': instance.alwaysShowTitleBar,
   'quickResponse': instance.quickResponse,
   'accessControl': instance.accessControl,

--- a/lib/models/generated/selector.freezed.dart
+++ b/lib/models/generated/selector.freezed.dart
@@ -1864,7 +1864,7 @@ as String?,
 /// @nodoc
 mixin _$TrayState {
 
- Mode get mode; int get port; bool get autoLaunch; bool get systemProxy; bool get tunEnable; bool get isStart; String? get locale; Brightness? get brightness; List<Group> get groups; SelectedMap get selectedMap; bool get wakelockEnabled; Map<String, int?> get delays; bool get trayEnhancement;
+ Mode get mode; int get port; bool get autoLaunch; bool get systemProxy; bool get tunEnable; bool get isStart; String? get locale; Brightness? get brightness; List<Group> get groups; SelectedMap get selectedMap; bool get wakelockEnabled; Map<String, int?> get delays; bool get trayEnhancement; bool get enableTraySpeed;
 /// Create a copy of TrayState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1875,16 +1875,16 @@ $TrayStateCopyWith<TrayState> get copyWith => _$TrayStateCopyWithImpl<TrayState>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is TrayState&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.port, port) || other.port == port)&&(identical(other.autoLaunch, autoLaunch) || other.autoLaunch == autoLaunch)&&(identical(other.systemProxy, systemProxy) || other.systemProxy == systemProxy)&&(identical(other.tunEnable, tunEnable) || other.tunEnable == tunEnable)&&(identical(other.isStart, isStart) || other.isStart == isStart)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.brightness, brightness) || other.brightness == brightness)&&const DeepCollectionEquality().equals(other.groups, groups)&&const DeepCollectionEquality().equals(other.selectedMap, selectedMap)&&(identical(other.wakelockEnabled, wakelockEnabled) || other.wakelockEnabled == wakelockEnabled)&&const DeepCollectionEquality().equals(other.delays, delays)&&(identical(other.trayEnhancement, trayEnhancement) || other.trayEnhancement == trayEnhancement));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TrayState&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.port, port) || other.port == port)&&(identical(other.autoLaunch, autoLaunch) || other.autoLaunch == autoLaunch)&&(identical(other.systemProxy, systemProxy) || other.systemProxy == systemProxy)&&(identical(other.tunEnable, tunEnable) || other.tunEnable == tunEnable)&&(identical(other.isStart, isStart) || other.isStart == isStart)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.brightness, brightness) || other.brightness == brightness)&&const DeepCollectionEquality().equals(other.groups, groups)&&const DeepCollectionEquality().equals(other.selectedMap, selectedMap)&&(identical(other.wakelockEnabled, wakelockEnabled) || other.wakelockEnabled == wakelockEnabled)&&const DeepCollectionEquality().equals(other.delays, delays)&&(identical(other.trayEnhancement, trayEnhancement) || other.trayEnhancement == trayEnhancement)&&(identical(other.enableTraySpeed, enableTraySpeed) || other.enableTraySpeed == enableTraySpeed));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,mode,port,autoLaunch,systemProxy,tunEnable,isStart,locale,brightness,const DeepCollectionEquality().hash(groups),const DeepCollectionEquality().hash(selectedMap),wakelockEnabled,const DeepCollectionEquality().hash(delays),trayEnhancement);
+int get hashCode => Object.hash(runtimeType,mode,port,autoLaunch,systemProxy,tunEnable,isStart,locale,brightness,const DeepCollectionEquality().hash(groups),const DeepCollectionEquality().hash(selectedMap),wakelockEnabled,const DeepCollectionEquality().hash(delays),trayEnhancement,enableTraySpeed);
 
 @override
 String toString() {
-  return 'TrayState(mode: $mode, port: $port, autoLaunch: $autoLaunch, systemProxy: $systemProxy, tunEnable: $tunEnable, isStart: $isStart, locale: $locale, brightness: $brightness, groups: $groups, selectedMap: $selectedMap, wakelockEnabled: $wakelockEnabled, delays: $delays, trayEnhancement: $trayEnhancement)';
+  return 'TrayState(mode: $mode, port: $port, autoLaunch: $autoLaunch, systemProxy: $systemProxy, tunEnable: $tunEnable, isStart: $isStart, locale: $locale, brightness: $brightness, groups: $groups, selectedMap: $selectedMap, wakelockEnabled: $wakelockEnabled, delays: $delays, trayEnhancement: $trayEnhancement, enableTraySpeed: $enableTraySpeed)';
 }
 
 
@@ -1895,7 +1895,7 @@ abstract mixin class $TrayStateCopyWith<$Res>  {
   factory $TrayStateCopyWith(TrayState value, $Res Function(TrayState) _then) = _$TrayStateCopyWithImpl;
 @useResult
 $Res call({
- Mode mode, int port, bool autoLaunch, bool systemProxy, bool tunEnable, bool isStart, String? locale, Brightness? brightness, List<Group> groups, SelectedMap selectedMap, bool wakelockEnabled, Map<String, int?> delays, bool trayEnhancement
+ Mode mode, int port, bool autoLaunch, bool systemProxy, bool tunEnable, bool isStart, String? locale, Brightness? brightness, List<Group> groups, SelectedMap selectedMap, bool wakelockEnabled, Map<String, int?> delays, bool trayEnhancement, bool enableTraySpeed
 });
 
 
@@ -1912,7 +1912,7 @@ class _$TrayStateCopyWithImpl<$Res>
 
 /// Create a copy of TrayState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mode = null,Object? port = null,Object? autoLaunch = null,Object? systemProxy = null,Object? tunEnable = null,Object? isStart = null,Object? locale = freezed,Object? brightness = freezed,Object? groups = null,Object? selectedMap = null,Object? wakelockEnabled = null,Object? delays = null,Object? trayEnhancement = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mode = null,Object? port = null,Object? autoLaunch = null,Object? systemProxy = null,Object? tunEnable = null,Object? isStart = null,Object? locale = freezed,Object? brightness = freezed,Object? groups = null,Object? selectedMap = null,Object? wakelockEnabled = null,Object? delays = null,Object? trayEnhancement = null,Object? enableTraySpeed = null,}) {
   return _then(_self.copyWith(
 mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
 as Mode,port: null == port ? _self.port : port // ignore: cast_nullable_to_non_nullable
@@ -1927,6 +1927,7 @@ as List<Group>,selectedMap: null == selectedMap ? _self.selectedMap : selectedMa
 as SelectedMap,wakelockEnabled: null == wakelockEnabled ? _self.wakelockEnabled : wakelockEnabled // ignore: cast_nullable_to_non_nullable
 as bool,delays: null == delays ? _self.delays : delays // ignore: cast_nullable_to_non_nullable
 as Map<String, int?>,trayEnhancement: null == trayEnhancement ? _self.trayEnhancement : trayEnhancement // ignore: cast_nullable_to_non_nullable
+as bool,enableTraySpeed: null == enableTraySpeed ? _self.enableTraySpeed : enableTraySpeed // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -2012,10 +2013,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Mode mode,  int port,  bool autoLaunch,  bool systemProxy,  bool tunEnable,  bool isStart,  String? locale,  Brightness? brightness,  List<Group> groups,  SelectedMap selectedMap,  bool wakelockEnabled,  Map<String, int?> delays,  bool trayEnhancement)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Mode mode,  int port,  bool autoLaunch,  bool systemProxy,  bool tunEnable,  bool isStart,  String? locale,  Brightness? brightness,  List<Group> groups,  SelectedMap selectedMap,  bool wakelockEnabled,  Map<String, int?> delays,  bool trayEnhancement,  bool enableTraySpeed)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _TrayState() when $default != null:
-return $default(_that.mode,_that.port,_that.autoLaunch,_that.systemProxy,_that.tunEnable,_that.isStart,_that.locale,_that.brightness,_that.groups,_that.selectedMap,_that.wakelockEnabled,_that.delays,_that.trayEnhancement);case _:
+return $default(_that.mode,_that.port,_that.autoLaunch,_that.systemProxy,_that.tunEnable,_that.isStart,_that.locale,_that.brightness,_that.groups,_that.selectedMap,_that.wakelockEnabled,_that.delays,_that.trayEnhancement,_that.enableTraySpeed);case _:
   return orElse();
 
 }
@@ -2033,10 +2034,10 @@ return $default(_that.mode,_that.port,_that.autoLaunch,_that.systemProxy,_that.t
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Mode mode,  int port,  bool autoLaunch,  bool systemProxy,  bool tunEnable,  bool isStart,  String? locale,  Brightness? brightness,  List<Group> groups,  SelectedMap selectedMap,  bool wakelockEnabled,  Map<String, int?> delays,  bool trayEnhancement)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Mode mode,  int port,  bool autoLaunch,  bool systemProxy,  bool tunEnable,  bool isStart,  String? locale,  Brightness? brightness,  List<Group> groups,  SelectedMap selectedMap,  bool wakelockEnabled,  Map<String, int?> delays,  bool trayEnhancement,  bool enableTraySpeed)  $default,) {final _that = this;
 switch (_that) {
 case _TrayState():
-return $default(_that.mode,_that.port,_that.autoLaunch,_that.systemProxy,_that.tunEnable,_that.isStart,_that.locale,_that.brightness,_that.groups,_that.selectedMap,_that.wakelockEnabled,_that.delays,_that.trayEnhancement);case _:
+return $default(_that.mode,_that.port,_that.autoLaunch,_that.systemProxy,_that.tunEnable,_that.isStart,_that.locale,_that.brightness,_that.groups,_that.selectedMap,_that.wakelockEnabled,_that.delays,_that.trayEnhancement,_that.enableTraySpeed);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -2053,10 +2054,10 @@ return $default(_that.mode,_that.port,_that.autoLaunch,_that.systemProxy,_that.t
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Mode mode,  int port,  bool autoLaunch,  bool systemProxy,  bool tunEnable,  bool isStart,  String? locale,  Brightness? brightness,  List<Group> groups,  SelectedMap selectedMap,  bool wakelockEnabled,  Map<String, int?> delays,  bool trayEnhancement)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Mode mode,  int port,  bool autoLaunch,  bool systemProxy,  bool tunEnable,  bool isStart,  String? locale,  Brightness? brightness,  List<Group> groups,  SelectedMap selectedMap,  bool wakelockEnabled,  Map<String, int?> delays,  bool trayEnhancement,  bool enableTraySpeed)?  $default,) {final _that = this;
 switch (_that) {
 case _TrayState() when $default != null:
-return $default(_that.mode,_that.port,_that.autoLaunch,_that.systemProxy,_that.tunEnable,_that.isStart,_that.locale,_that.brightness,_that.groups,_that.selectedMap,_that.wakelockEnabled,_that.delays,_that.trayEnhancement);case _:
+return $default(_that.mode,_that.port,_that.autoLaunch,_that.systemProxy,_that.tunEnable,_that.isStart,_that.locale,_that.brightness,_that.groups,_that.selectedMap,_that.wakelockEnabled,_that.delays,_that.trayEnhancement,_that.enableTraySpeed);case _:
   return null;
 
 }
@@ -2068,7 +2069,7 @@ return $default(_that.mode,_that.port,_that.autoLaunch,_that.systemProxy,_that.t
 
 
 class _TrayState implements TrayState {
-  const _TrayState({required this.mode, required this.port, required this.autoLaunch, required this.systemProxy, required this.tunEnable, required this.isStart, required this.locale, required this.brightness, required final  List<Group> groups, required final  SelectedMap selectedMap, this.wakelockEnabled = false, final  Map<String, int?> delays = const {}, this.trayEnhancement = true}): _groups = groups,_selectedMap = selectedMap,_delays = delays;
+  const _TrayState({required this.mode, required this.port, required this.autoLaunch, required this.systemProxy, required this.tunEnable, required this.isStart, required this.locale, required this.brightness, required final  List<Group> groups, required final  SelectedMap selectedMap, this.wakelockEnabled = false, final  Map<String, int?> delays = const {}, this.trayEnhancement = true, this.enableTraySpeed = false}): _groups = groups,_selectedMap = selectedMap,_delays = delays;
   
 
 @override final  Mode mode;
@@ -2102,6 +2103,7 @@ class _TrayState implements TrayState {
 }
 
 @override@JsonKey() final  bool trayEnhancement;
+@override@JsonKey() final  bool enableTraySpeed;
 
 /// Create a copy of TrayState
 /// with the given fields replaced by the non-null parameter values.
@@ -2113,16 +2115,16 @@ _$TrayStateCopyWith<_TrayState> get copyWith => __$TrayStateCopyWithImpl<_TraySt
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TrayState&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.port, port) || other.port == port)&&(identical(other.autoLaunch, autoLaunch) || other.autoLaunch == autoLaunch)&&(identical(other.systemProxy, systemProxy) || other.systemProxy == systemProxy)&&(identical(other.tunEnable, tunEnable) || other.tunEnable == tunEnable)&&(identical(other.isStart, isStart) || other.isStart == isStart)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.brightness, brightness) || other.brightness == brightness)&&const DeepCollectionEquality().equals(other._groups, _groups)&&const DeepCollectionEquality().equals(other._selectedMap, _selectedMap)&&(identical(other.wakelockEnabled, wakelockEnabled) || other.wakelockEnabled == wakelockEnabled)&&const DeepCollectionEquality().equals(other._delays, _delays)&&(identical(other.trayEnhancement, trayEnhancement) || other.trayEnhancement == trayEnhancement));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TrayState&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.port, port) || other.port == port)&&(identical(other.autoLaunch, autoLaunch) || other.autoLaunch == autoLaunch)&&(identical(other.systemProxy, systemProxy) || other.systemProxy == systemProxy)&&(identical(other.tunEnable, tunEnable) || other.tunEnable == tunEnable)&&(identical(other.isStart, isStart) || other.isStart == isStart)&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.brightness, brightness) || other.brightness == brightness)&&const DeepCollectionEquality().equals(other._groups, _groups)&&const DeepCollectionEquality().equals(other._selectedMap, _selectedMap)&&(identical(other.wakelockEnabled, wakelockEnabled) || other.wakelockEnabled == wakelockEnabled)&&const DeepCollectionEquality().equals(other._delays, _delays)&&(identical(other.trayEnhancement, trayEnhancement) || other.trayEnhancement == trayEnhancement)&&(identical(other.enableTraySpeed, enableTraySpeed) || other.enableTraySpeed == enableTraySpeed));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,mode,port,autoLaunch,systemProxy,tunEnable,isStart,locale,brightness,const DeepCollectionEquality().hash(_groups),const DeepCollectionEquality().hash(_selectedMap),wakelockEnabled,const DeepCollectionEquality().hash(_delays),trayEnhancement);
+int get hashCode => Object.hash(runtimeType,mode,port,autoLaunch,systemProxy,tunEnable,isStart,locale,brightness,const DeepCollectionEquality().hash(_groups),const DeepCollectionEquality().hash(_selectedMap),wakelockEnabled,const DeepCollectionEquality().hash(_delays),trayEnhancement,enableTraySpeed);
 
 @override
 String toString() {
-  return 'TrayState(mode: $mode, port: $port, autoLaunch: $autoLaunch, systemProxy: $systemProxy, tunEnable: $tunEnable, isStart: $isStart, locale: $locale, brightness: $brightness, groups: $groups, selectedMap: $selectedMap, wakelockEnabled: $wakelockEnabled, delays: $delays, trayEnhancement: $trayEnhancement)';
+  return 'TrayState(mode: $mode, port: $port, autoLaunch: $autoLaunch, systemProxy: $systemProxy, tunEnable: $tunEnable, isStart: $isStart, locale: $locale, brightness: $brightness, groups: $groups, selectedMap: $selectedMap, wakelockEnabled: $wakelockEnabled, delays: $delays, trayEnhancement: $trayEnhancement, enableTraySpeed: $enableTraySpeed)';
 }
 
 
@@ -2133,7 +2135,7 @@ abstract mixin class _$TrayStateCopyWith<$Res> implements $TrayStateCopyWith<$Re
   factory _$TrayStateCopyWith(_TrayState value, $Res Function(_TrayState) _then) = __$TrayStateCopyWithImpl;
 @override @useResult
 $Res call({
- Mode mode, int port, bool autoLaunch, bool systemProxy, bool tunEnable, bool isStart, String? locale, Brightness? brightness, List<Group> groups, SelectedMap selectedMap, bool wakelockEnabled, Map<String, int?> delays, bool trayEnhancement
+ Mode mode, int port, bool autoLaunch, bool systemProxy, bool tunEnable, bool isStart, String? locale, Brightness? brightness, List<Group> groups, SelectedMap selectedMap, bool wakelockEnabled, Map<String, int?> delays, bool trayEnhancement, bool enableTraySpeed
 });
 
 
@@ -2150,7 +2152,7 @@ class __$TrayStateCopyWithImpl<$Res>
 
 /// Create a copy of TrayState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? mode = null,Object? port = null,Object? autoLaunch = null,Object? systemProxy = null,Object? tunEnable = null,Object? isStart = null,Object? locale = freezed,Object? brightness = freezed,Object? groups = null,Object? selectedMap = null,Object? wakelockEnabled = null,Object? delays = null,Object? trayEnhancement = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? mode = null,Object? port = null,Object? autoLaunch = null,Object? systemProxy = null,Object? tunEnable = null,Object? isStart = null,Object? locale = freezed,Object? brightness = freezed,Object? groups = null,Object? selectedMap = null,Object? wakelockEnabled = null,Object? delays = null,Object? trayEnhancement = null,Object? enableTraySpeed = null,}) {
   return _then(_TrayState(
 mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
 as Mode,port: null == port ? _self.port : port // ignore: cast_nullable_to_non_nullable
@@ -2165,6 +2167,7 @@ as List<Group>,selectedMap: null == selectedMap ? _self._selectedMap : selectedM
 as SelectedMap,wakelockEnabled: null == wakelockEnabled ? _self.wakelockEnabled : wakelockEnabled // ignore: cast_nullable_to_non_nullable
 as bool,delays: null == delays ? _self._delays : delays // ignore: cast_nullable_to_non_nullable
 as Map<String, int?>,trayEnhancement: null == trayEnhancement ? _self.trayEnhancement : trayEnhancement // ignore: cast_nullable_to_non_nullable
+as bool,enableTraySpeed: null == enableTraySpeed ? _self.enableTraySpeed : enableTraySpeed // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/lib/models/selector.dart
+++ b/lib/models/selector.dart
@@ -76,6 +76,7 @@ abstract class TrayState with _$TrayState {
     @Default(false) bool wakelockEnabled,
     @Default({}) Map<String, int?> delays,
     @Default(true) bool trayEnhancement,
+    @Default(false) bool enableTraySpeed,
   }) = _TrayState;
 }
 

--- a/lib/providers/generated/state.g.dart
+++ b/lib/providers/generated/state.g.dart
@@ -131,7 +131,7 @@ final proxyStateProvider = AutoDisposeProvider<ProxyState>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef ProxyStateRef = AutoDisposeProviderRef<ProxyState>;
-String _$trayStateHash() => r'08a611775e36405fa18fd6f047ae423bcb2efe83';
+String _$trayStateHash() => r'0a29fc928f71098761ddac2121022c39749aa864';
 
 /// See also [trayState].
 @ProviderFor(trayState)

--- a/lib/providers/state.dart
+++ b/lib/providers/state.dart
@@ -222,6 +222,7 @@ TrayState trayState(Ref ref) {
     selectedMap: selectedMap,
     wakelockEnabled: wakelockEnabled,
     trayEnhancement: vpnProps.trayEnhancement,
+    enableTraySpeed: vpnProps.enableTraySpeed,
   );
 }
 

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -207,10 +207,11 @@ class GlobalState {
     }
     render?.pause();
 
-    final networkSpeedNotification =
-        system.isAndroid &&
-        appController.ref.read(vpnSettingProvider).networkSpeedNotification;
-    if (!networkSpeedNotification) {
+    final vpnProps = appController.ref.read(vpnSettingProvider);
+    final keepTrafficUpdates =
+        (system.isAndroid && vpnProps.networkSpeedNotification) ||
+        (system.isMacOS && vpnProps.enableTraySpeed);
+    if (!keepTrafficUpdates) {
       stopUpdateTasks();
     }
 

--- a/lib/views/other_setting.dart
+++ b/lib/views/other_setting.dart
@@ -509,6 +509,30 @@ class TrayEnhancementItem extends ConsumerWidget {
   }
 }
 
+class TraySpeedItem extends ConsumerWidget {
+  const TraySpeedItem({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final enableTraySpeed = ref.watch(
+      vpnSettingProvider.select((state) => state.enableTraySpeed),
+    );
+    return ListItem.switchItem(
+      title: Text(appLocalizations.enableTraySpeed),
+      subtitle: Text(appLocalizations.enableTraySpeedDesc),
+      delegate: SwitchDelegate(
+        value: enableTraySpeed,
+        onChanged: (bool value) async {
+          ref
+              .read(vpnSettingProvider.notifier)
+              .updateState((state) => state.copyWith(enableTraySpeed: value));
+          await globalState.appController.updateTray();
+        },
+      ),
+    );
+  }
+}
+
 class OtherSettingView extends ConsumerWidget {
   const OtherSettingView({super.key});
 
@@ -522,6 +546,7 @@ class OtherSettingView extends ConsumerWidget {
       const DisableQuicSection(),
       if (system.isAndroid) const NetworkSpeedNotificationItem(),
       if (!system.isAndroid) const TrayEnhancementItem(),
+      if (system.isMacOS) const TraySpeedItem(),
       if (system.isWindows) const HighPriorityItem(),
       if (system.isWindows) const NetworkFixItem(),
       if (system.isAndroid) const BatteryOptimizationItem(),

--- a/lib/views/tools.dart
+++ b/lib/views/tools.dart
@@ -619,6 +619,16 @@ class _ToolViewState extends ConsumerState<ToolsView> {
         ),
       ),
       _SearchItem(
+        title: appLocalizations.enableTraySpeed,
+        subtitle: appLocalizations.enableTraySpeedDesc,
+        category: otherSettingsCategory,
+        onTap: (context, _) => _pushPage(
+          context,
+          appLocalizations.otherSettings,
+          const OtherSettingView(),
+        ),
+      ),
+      _SearchItem(
         title: appLocalizations.highPriority,
         subtitle: appLocalizations.highPriorityDesc,
         category: otherSettingsCategory,

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -45,7 +45,7 @@ SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   HotKey: e96d8a2ddbf4591131e2bb3f54e69554d90cdca6
   hotkey_manager_macos: a4317849af96d2430fa89944d3c58977ca089fbe
-  tray_manager: a104b5c81b578d83f3c3d0f40a997c8b10810166
+  tray_manager: 9064e219c56d75c476e46b9a21182087930baf90
   window_ext: 4afef727fe428b30c68ce800ba92e890fd329f63
 
 PODFILE CHECKSUM: 9ebaf0ce3d369aaa26a9ea0e159195ed94724cf3

--- a/plugins/tray_manager/lib/src/tray_manager.dart
+++ b/plugins/tray_manager/lib/src/tray_manager.dart
@@ -235,6 +235,30 @@ class TrayManager {
     await _channel.invokeMethod('setTitle', arguments);
   }
 
+  /// 在 macOS 菜单栏图标右侧显示两行上传和下载速率。
+  Future<void> setSpeedTitle({
+    required int upload,
+    required int download,
+    bool active = true,
+  }) async {
+    final Map<String, dynamic> arguments = {
+      'upload': upload,
+      'download': download,
+      'active': active,
+    };
+    await _channel.invokeMethod('setSpeedTitle', arguments);
+  }
+
+  /// 设置 macOS 菜单栏图标是否处于正在接管系统流量的状态。
+  Future<void> setActive(bool active) async {
+    await _channel.invokeMethod('setActive', {'active': active});
+  }
+
+  /// 清除 macOS 菜单栏图标右侧的速率。
+  Future<void> clearSpeedTitle() async {
+    await _channel.invokeMethod('clearSpeedTitle');
+  }
+
   /// Sets the context menu for this icon.
   ///
   Future<void> setContextMenu(

--- a/plugins/tray_manager/macos/Classes/TrayIcon.swift
+++ b/plugins/tray_manager/macos/Classes/TrayIcon.swift
@@ -8,12 +8,36 @@
 import Cocoa
 
 public class TrayIcon: NSView {
+    private static let inactiveColor = NSColor(
+        srgbRed: 202.0 / 255.0,
+        green: 202.0 / 255.0,
+        blue: 202.0 / 255.0,
+        alpha: 1
+    )
+    private static let speedFontSize: CGFloat = 9.5
+    private static let speedLineHeight: CGFloat = 10
+    private static let speedExtraWidth: CGFloat = 30
+    private static let speedMinimumWidth: CGFloat = 58
+    private static let speedDisplayThreshold = 1000.0
+    private static let speedUnits = ["B/s", "K/s", "M/s", "G/s", "T/s"]
+    private static let speedScales = [
+        1.0,
+        1024.0,
+        1024.0 * 1024.0,
+        1024.0 * 1024.0 * 1024.0,
+        1024.0 * 1024.0 * 1024.0 * 1024.0,
+    ]
+
     public var onTrayIconMouseDown:(() -> Void)?
     public var onTrayIconMouseUp:(() -> Void)?
     public var onTrayIconRightMouseDown:(() -> Void)?
     public var onTrayIconRightMouseUp:(() -> Void)?
     
     var statusItem: NSStatusItem?
+    private var sourceImage: NSImage?
+    private var isActive = true
+    private var lastSpeedTitle: String?
+    private var lastSpeedActive: Bool?
     
     public init() {
         super.init(frame: NSRect.zero)
@@ -30,32 +54,183 @@ public class TrayIcon: NSView {
     }
     
     public func setImage(_ image: NSImage, _ imagePosition: String) {
+        sourceImage = image
         if let button = statusItem?.button {
-            button.image = image
+            updateImageAppearance(button)
             setImagePosition(imagePosition)
+            syncClickTargetFrame(button)
         }
-
-
-        self.frame = statusItem!.button!.frame
     }
     
     public func setImagePosition(_ imagePosition: String) {
         if let button = statusItem?.button {
             button.imagePosition = imagePosition == "right" ? NSControl.ImagePosition.imageRight : NSControl.ImagePosition.imageLeft
+            syncClickTargetFrame(button)
         }
-        self.frame = statusItem!.button!.frame
     }
     
     public func removeImage() {
-        statusItem?.button?.image = nil
-        self.frame = statusItem!.button!.frame
+        sourceImage = nil
+        if let button = statusItem?.button {
+            button.image = nil
+            syncClickTargetFrame(button)
+        }
     }
     
     public func setTitle(_ title: String) {
         if let button = statusItem?.button {
             button.title  = title
+            syncClickTargetFrame(button)
         }
-        self.frame = statusItem!.button!.frame
+        lastSpeedTitle = nil
+        lastSpeedActive = nil
+    }
+
+    public func setActive(_ active: Bool) {
+        isActive = active
+        if let button = statusItem?.button {
+            updateImageAppearance(button)
+        }
+    }
+
+    public func setSpeedTitle(
+        upload: UInt64,
+        download: UInt64,
+        active: Bool
+    ) {
+        let uploadText = formatSpeed(upload)
+        let downloadText = formatSpeed(download)
+        let title = "\(leftPad(uploadText, width: 6))\n\(leftPad(downloadText, width: 6))"
+        if lastSpeedTitle == title && lastSpeedActive == active {
+            return
+        }
+        guard let statusItem, let button = statusItem.button else {
+            return
+        }
+
+        let font = NSFont.monospacedSystemFont(
+            ofSize: Self.speedFontSize,
+            weight: .regular
+        )
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .right
+        paragraphStyle.lineBreakMode = .byClipping
+        paragraphStyle.lineSpacing = 0
+        paragraphStyle.lineHeightMultiple = 1
+        paragraphStyle.minimumLineHeight = Self.speedLineHeight
+        paragraphStyle.maximumLineHeight = Self.speedLineHeight
+        paragraphStyle.paragraphSpacingBefore = 0
+
+        let glyphHeight = font.ascender - font.descender
+        let freeSpace = Self.speedLineHeight * 2 - button.bounds.height
+        let baselineOffset = -(glyphHeight / 3) + freeSpace / 2
+        button.title = title
+        let attributedTitle = NSMutableAttributedString(
+            attributedString: button.attributedTitle
+        )
+        let fullRange = NSRange(
+            location: 0,
+            length: attributedTitle.length
+        )
+        attributedTitle.addAttributes(
+            [
+                .font: font,
+                .paragraphStyle: paragraphStyle,
+                .baselineOffset: baselineOffset,
+            ],
+            range: fullRange
+        )
+        if !active {
+            attributedTitle.addAttribute(
+                .foregroundColor,
+                value: Self.inactiveColor,
+                range: fullRange
+            )
+        }
+
+        statusItem.length = max(
+            ceil(attributedTitle.size().width) + Self.speedExtraWidth,
+            Self.speedMinimumWidth
+        )
+        button.attributedTitle = attributedTitle
+        syncClickTargetFrame(button)
+        lastSpeedTitle = title
+        lastSpeedActive = active
+    }
+
+    public func clearSpeedTitle() {
+        lastSpeedTitle = nil
+        lastSpeedActive = nil
+        statusItem?.length = NSStatusItem.variableLength
+        if let button = statusItem?.button {
+            button.attributedTitle = NSAttributedString(string: "")
+            syncClickTargetFrame(button)
+        }
+    }
+
+    private func formatSpeed(_ bytesPerSecond: UInt64) -> String {
+        if bytesPerSecond < UInt64(Self.speedDisplayThreshold) {
+            return "\(bytesPerSecond)B/s"
+        }
+
+        let bitIndex = Int(log2(Double(bytesPerSecond))) / 10
+        var unitIndex = min(bitIndex, Self.speedUnits.count - 1)
+        var value = Double(bytesPerSecond) / Self.speedScales[unitIndex]
+        if value.rounded() >= Self.speedDisplayThreshold &&
+            unitIndex < Self.speedUnits.count - 1 {
+            unitIndex += 1
+            value = Double(bytesPerSecond) / Self.speedScales[unitIndex]
+        }
+
+        let unit = Self.speedUnits[unitIndex]
+        if value < 9.95 {
+            let number = String(
+                format: "%.1f",
+                locale: Locale(identifier: "en_US_POSIX"),
+                value
+            )
+            return "\(number)\(unit)"
+        }
+        return "\(Int(value.rounded()))\(unit)"
+    }
+
+    private func leftPad(_ value: String, width: Int) -> String {
+        let padding = max(0, width - value.count)
+        return String(repeating: " ", count: padding) + value
+    }
+
+    private func updateImageAppearance(_ button: NSStatusBarButton) {
+        guard let sourceImage else {
+            return
+        }
+        if isActive {
+            button.contentTintColor = nil
+            sourceImage.isTemplate = true
+            button.image = sourceImage
+            return
+        }
+        button.image = tintedImage(sourceImage, color: Self.inactiveColor)
+        button.contentTintColor = nil
+    }
+
+    private func tintedImage(_ image: NSImage, color: NSColor) -> NSImage {
+        let tintedImage = NSImage(size: image.size)
+        tintedImage.lockFocus()
+        color.setFill()
+        NSRect(origin: .zero, size: image.size).fill()
+        image.draw(
+            in: NSRect(origin: .zero, size: image.size),
+            from: .zero,
+            operation: .destinationIn,
+            fraction: 1
+        )
+        tintedImage.unlockFocus()
+        tintedImage.isTemplate = false
+        return tintedImage
+    }
+
+    private func syncClickTargetFrame(_ button: NSStatusBarButton) {
+        self.frame = button.bounds
     }
     
     public func setToolTip(_ toolTip: String) {

--- a/plugins/tray_manager/macos/Classes/TrayManagerPlugin.swift
+++ b/plugins/tray_manager/macos/Classes/TrayManagerPlugin.swift
@@ -61,6 +61,15 @@ public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
         case "setTitle":
             setTitle(call, result: result)
             break
+        case "setSpeedTitle":
+            setSpeedTitle(call, result: result)
+            break
+        case "setActive":
+            setActive(call, result: result)
+            break
+        case "clearSpeedTitle":
+            clearSpeedTitle(call, result: result)
+            break
         case "setContextMenu":
             setContextMenu(call, result: result)
             break
@@ -191,6 +200,33 @@ public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
         
         trayIcon?.setTitle(title)
         
+        result(true)
+    }
+
+    public func setSpeedTitle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let args = call.arguments as? [String: Any]
+        let upload = (args?["upload"] as? NSNumber)?.uint64Value ?? 0
+        let download = (args?["download"] as? NSNumber)?.uint64Value ?? 0
+        let active = args?["active"] as? Bool ?? true
+
+        trayIcon?.setSpeedTitle(
+            upload: upload,
+            download: download,
+            active: active
+        )
+
+        result(true)
+    }
+
+    public func setActive(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let args = call.arguments as? [String: Any]
+        let active = args?["active"] as? Bool ?? true
+        trayIcon?.setActive(active)
+        result(true)
+    }
+
+    public func clearSpeedTitle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        trayIcon?.clearSpeedTitle()
         result(true)
     }
     

--- a/test/models/tray_speed_config_test.dart
+++ b/test/models/tray_speed_config_test.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+
+import 'package:bett_box/models/config.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('VpnProps 托盘速率', () {
+    test('默认关闭', () {
+      expect(const VpnProps().enableTraySpeed, isFalse);
+    });
+
+    test('序列化后能够恢复开关状态', () {
+      const props = VpnProps(enableTraySpeed: true);
+
+      final restored = VpnProps.fromJson(
+        jsonDecode(jsonEncode(props.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(restored.enableTraySpeed, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## 功能说明

为 macOS 菜单栏图标增加可选的实时上传、下载速率显示，用于在不打开主窗口的情况下确认当前流量与接管状态。

本 PR 只包含速率显示，不包含托盘点击行为或隐藏策略组快捷访问。

## 使用方式

入口：

```text
更多 → 增强工具 → 启用托盘速率
```

- 默认关闭，开启后在菜单栏图标右侧以两行显示上传和下载速率。
- 支持 `B/s`、`K/s`、`M/s`、`G/s`、`T/s`。
- 数值较长时根据文本实际宽度调整 `NSStatusItem`，不会使用固定宽度截断速率。
- Bettbox 停止，或系统代理与虚拟网卡均未开启时，图标和速率文字使用 `#CACACA` 灰色。
- 代理实际生效时继续使用 macOS 模板图标和系统自适应前景色。

Related to #154

## 主要修改

### 1. 新增独立、默认关闭的持久化设置

旧配置没有速率开关：

```dart
@Default(false) bool trayEnhancement,
```

新配置增加独立字段，不改变现有托盘菜单设置：

```dart
@Default(false) bool trayEnhancement,
@Default(false) bool enableTraySpeed,
```

该字段进入现有 `VpnProps` JSON 持久化链路，因此本地配置备份和 WebDAV 同步都会携带它；旧版本配置缺少字段时按默认值 `false` 读取。

### 2. 窗口隐藏后仍保留必要的流量采样

旧代码在桌面窗口隐藏后会停止更新任务：

```dart
if (!networkSpeedNotification) {
  stopUpdateTasks();
}
```

新代码只在 Android 通知和 macOS 托盘速率都不需要时停止：

```dart
final keepTrafficUpdates =
    (system.isAndroid && vpnProps.networkSpeedNotification) ||
    (system.isMacOS && vpnProps.enableTraySpeed);
if (!keepTrafficUpdates) {
  stopUpdateTasks();
}
```

这保证关闭主窗口后菜单栏仍能更新，同时没有开启速率功能时不会额外保留流量轮询。

### 3. 运行状态使用“总开关 + 实际接管方式”判断

旧托盘图标只根据总开关判断：

```dart
isStart: trayState.isStart
```

新逻辑要求 Bettbox 已启动，且系统代理或虚拟网卡至少有一个开启：

```dart
_trayTrafficActive =
    trayState.isStart && (trayState.systemProxy || trayState.tunEnable);
```

因此“只开启总开关但没有任何接管方式”会明确显示为未接管状态。

### 4. macOS 原生速率排版与动态宽度

原生层新增 `setSpeedTitle`、`setActive` 和 `clearSpeedTitle`。速率使用等宽字体、右对齐和两行固定行高；宽度根据 `attributedTitle.size().width` 计算：

```swift
statusItem.length = max(
    ceil(attributedTitle.size().width) + Self.speedExtraWidth,
    Self.speedMinimumWidth
)
```

停止显示时恢复 `NSStatusItem.variableLength`，不会长期占用额外菜单栏宽度。

## 性能边界

- 仅 macOS 且用户开启速率功能时，在后台继续获取实时流量。
- 相同上传、下载和活跃状态不会重复写入原生菜单栏。
- 开关关闭后立即清除速率标题并释放额外宽度。

## 验证

- `flutter analyze`：通过。
- `flutter test`：11 项全部通过。
- 新增测试覆盖默认关闭及 JSON 序列化恢复。
- macOS 自定义构建包实机验证：不同速率单位、动态宽度、停止状态灰色和启用状态自适应颜色正常。

这是关闭的 #321 拆分出的独立功能 PR。
