### PR TITLE
功能：按住 Option 临时显示隐藏策略组

### DIFF
--- a/lib/common/tray.dart
+++ b/lib/common/tray.dart
@@ -105,6 +105,7 @@ class Tray {
     required TrayState trayState,
     bool focus = false,
     bool silent = false,
+    List<Group>? groupsOverride,
   }) async {
     if (_isUpdating) return;
     _isUpdating = true;
@@ -146,8 +147,9 @@ class Tray {
       );
     }
     menuItems.add(MenuItem.separator());
+    final menuGroups = groupsOverride ?? trayState.groups;
     if (trayState.trayEnhancement) {
-      for (final group in trayState.groups) {
+      for (final group in menuGroups) {
         List<MenuItem> subMenuItems = [];
 
         final isTestingThisGroup =
@@ -200,7 +202,7 @@ class Tray {
           ),
         );
       }
-      if (trayState.groups.isNotEmpty) {
+      if (menuGroups.isNotEmpty) {
         menuItems.add(MenuItem.separator());
       }
     }
@@ -307,6 +309,18 @@ class Tray {
         );
       }
     }
+  }
+
+  Future<void> showContextMenu({
+    required TrayState trayState,
+    required List<Group> groups,
+  }) async {
+    _debounceTimer?.cancel();
+    while (_isUpdating) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    await _doUpdate(trayState: trayState, groupsOverride: groups);
+    await trayManager.popUpContextMenu();
   }
 
   MenuItem _buildCopyEnvSubmenu(int port) {

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -1427,9 +1427,8 @@ class AppController {
         ageSecretKey: ageSecretKey,
       ).update();
       if (globalState.navigatorKey.currentState?.canPop() ?? false) {
-        globalState.navigatorKey.currentState?.popUntil(
-          (route) => route.isFirst,
-        );
+        globalState.navigatorKey.currentState
+            ?.popUntil((route) => route.isFirst);
       }
       toProfiles();
       await addProfile(profile);
@@ -1489,8 +1488,9 @@ class AppController {
       }
 
       if (successCount > 0) {
-        globalState.navigatorKey.currentState
-            ?.popUntil((route) => route.isFirst);
+        globalState.navigatorKey.currentState?.popUntil(
+          (route) => route.isFirst,
+        );
         toProfiles();
       }
     } finally {
@@ -1824,6 +1824,18 @@ class AppController {
       silent: silent,
       force: force,
     );
+  }
+
+  Future<void> showTrayMenu({bool includeHiddenItems = false}) async {
+    final trayState = _ref.read(trayStateProvider);
+    final groups = includeHiddenItems
+        ? getVisibleGroups(
+            mode: trayState.mode,
+            groups: _ref.read(groupsProvider),
+            showHiddenItems: true,
+          )
+        : trayState.groups;
+    await tray.showContextMenu(trayState: trayState, groups: groups);
   }
 
   Future<void> _processRecoveryArchive(

--- a/lib/manager/tray_manager.dart
+++ b/lib/manager/tray_manager.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:bett_box/common/common.dart';
+import 'package:bett_box/providers/config.dart';
 import 'package:bett_box/providers/state.dart';
 import 'package:bett_box/state.dart';
 import 'package:flutter/material.dart';
@@ -31,15 +34,35 @@ class _TrayContainerState extends ConsumerState<TrayManager> with TrayListener {
     return widget.child;
   }
 
+  bool get _shouldTemporarilyShowHiddenItems {
+    if (!system.isMacOS || !trayManager.isOptionKeyPressed) {
+      return false;
+    }
+    return !ref.read(
+      proxiesStyleSettingProvider.select((state) => state.showHiddenItems),
+    );
+  }
+
   @override
   void onTrayIconRightMouseDown() {
+    if (_shouldTemporarilyShowHiddenItems) {
+      unawaited(
+        globalState.appController.showTrayMenu(includeHiddenItems: true),
+      );
+      return;
+    }
     // ignore: deprecated_member_use
     trayManager.popUpContextMenu(bringAppToFront: true);
   }
 
-
   @override
-  onTrayIconMouseDown() {
+  void onTrayIconMouseDown() {
+    if (_shouldTemporarilyShowHiddenItems) {
+      unawaited(
+        globalState.appController.showTrayMenu(includeHiddenItems: true),
+      );
+      return;
+    }
     window?.show();
   }
 

--- a/plugins/tray_manager/lib/src/tray_manager.dart
+++ b/plugins/tray_manager/lib/src/tray_manager.dart
@@ -65,6 +65,10 @@ class TrayManager {
 
   bool get isMenuOpen => _menuOpenState.isOpen;
 
+  bool _isOptionKeyPressed = false;
+
+  bool get isOptionKeyPressed => _isOptionKeyPressed;
+
   Map<String, dynamic> _menuToJson(Menu menu) {
     return {
       'items': menu.items?.map(_menuItemToJson).toList(),
@@ -95,6 +99,9 @@ class TrayManager {
       return;
     }
 
+    final arguments = call.arguments;
+    _isOptionKeyPressed =
+        arguments is Map && arguments['optionKeyPressed'] == true;
     for (final TrayListener listener in _listeners) {
       switch (call.method) {
         case kEventOnTrayIconMouseDown:

--- a/plugins/tray_manager/macos/Classes/TrayIcon.swift
+++ b/plugins/tray_manager/macos/Classes/TrayIcon.swift
@@ -8,10 +8,10 @@
 import Cocoa
 
 public class TrayIcon: NSView {
-    public var onTrayIconMouseDown:(() -> Void)?
-    public var onTrayIconMouseUp:(() -> Void)?
-    public var onTrayIconRightMouseDown:(() -> Void)?
-    public var onTrayIconRightMouseUp:(() -> Void)?
+    public var onTrayIconMouseDown:((Bool) -> Void)?
+    public var onTrayIconMouseUp:((Bool) -> Void)?
+    public var onTrayIconRightMouseDown:((Bool) -> Void)?
+    public var onTrayIconRightMouseUp:((Bool) -> Void)?
     
     var statusItem: NSStatusItem?
     
@@ -66,19 +66,19 @@ public class TrayIcon: NSView {
     
     public override func mouseDown(with event: NSEvent) {
         statusItem?.button?.highlight(true)
-        self.onTrayIconMouseDown!()
+        self.onTrayIconMouseDown!(event.modifierFlags.contains(.option))
     }
     
     public override func mouseUp(with event: NSEvent) {
         statusItem?.button?.highlight(false)
-        self.onTrayIconMouseUp!()
+        self.onTrayIconMouseUp!(event.modifierFlags.contains(.option))
     }
     
     public override func rightMouseDown(with event: NSEvent) {
-        self.onTrayIconRightMouseDown!()
+        self.onTrayIconRightMouseDown!(event.modifierFlags.contains(.option))
     }
     
     public override func rightMouseUp(with event: NSEvent) {
-        self.onTrayIconRightMouseUp!()
+        self.onTrayIconRightMouseUp!(event.modifierFlags.contains(.option))
     }
 }

--- a/plugins/tray_manager/macos/Classes/TrayManagerPlugin.swift
+++ b/plugins/tray_manager/macos/Classes/TrayManagerPlugin.swift
@@ -148,17 +148,17 @@ public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
         
         if (trayIcon == nil) {
             trayIcon = TrayIcon()
-            trayIcon?.onTrayIconMouseDown = { () in
-                self.channel.invokeMethod(kEventOnTrayIconMouseDown, arguments: nil, result: nil)
+            trayIcon?.onTrayIconMouseDown = { (optionKeyPressed) in
+                self.channel.invokeMethod(kEventOnTrayIconMouseDown, arguments: ["optionKeyPressed": optionKeyPressed], result: nil)
             }
-            trayIcon?.onTrayIconMouseUp = { () in
-                self.channel.invokeMethod(kEventOnTrayIconMouseUp, arguments: nil, result: nil)
+            trayIcon?.onTrayIconMouseUp = { (optionKeyPressed) in
+                self.channel.invokeMethod(kEventOnTrayIconMouseUp, arguments: ["optionKeyPressed": optionKeyPressed], result: nil)
             }
-            trayIcon?.onTrayIconRightMouseDown = { () in
-                self.channel.invokeMethod(kEventOnTrayIconRightMouseDown, arguments: nil, result: nil)
+            trayIcon?.onTrayIconRightMouseDown = { (optionKeyPressed) in
+                self.channel.invokeMethod(kEventOnTrayIconRightMouseDown, arguments: ["optionKeyPressed": optionKeyPressed], result: nil)
             }
-            trayIcon?.onTrayIconRightMouseUp = { () in
-                self.channel.invokeMethod(kEventOnTrayIconRightMouseUp, arguments: nil, result: nil)
+            trayIcon?.onTrayIconRightMouseUp = { (optionKeyPressed) in
+                self.channel.invokeMethod(kEventOnTrayIconRightMouseUp, arguments: ["optionKeyPressed": optionKeyPressed], result: nil)
             }
         }
         


### PR DESCRIPTION
## 功能说明

补全隐藏策略组的 macOS 快捷访问：当“显示隐藏项”关闭时，按住 Option 点击菜单栏图标，可以临时打开包含 `hidden` 策略组的托盘菜单。

“显示隐藏项”持久开关已经进入上游 `main`，本 PR 只提交尚未合入的 Option 临时访问能力。

## 使用方式

持久显示入口：

```text
代理 → 右上角三个点 → 显示隐藏项
```

临时显示：

1. 保持“显示隐藏项”关闭。
2. 按住 Option。
3. 点击 macOS 菜单栏 Bettbox 图标。
4. 本次弹出的托盘菜单会按照配置原始顺序包含 `hidden` 策略组。

松开 Option 后不会修改持久配置；下次普通点击仍按“显示隐藏项”设置展示。如果开关已经开启，托盘原本就包含隐藏项，不再执行临时覆盖。

Closes #294

## 关键逻辑对比

### 1. 原生层传递本次点击的 Option 状态

旧回调不携带修饰键：

```swift
public var onTrayIconMouseDown:(() -> Void)?
self.onTrayIconMouseDown!()
```

新回调传递事件当时的 Option 状态：

```swift
public var onTrayIconMouseDown:((Bool) -> Void)?
self.onTrayIconMouseDown!(event.modifierFlags.contains(.option))
```

`TrayManagerPlugin` 将该值放入 MethodChannel 参数，Dart 侧只保存当前原生事件携带的状态，不通过键盘轮询猜测。

### 2. 仅在 macOS 且持久开关关闭时启用快捷访问

```dart
bool get _shouldTemporarilyShowHiddenItems {
  if (!system.isMacOS || !trayManager.isOptionKeyPressed) {
    return false;
  }
  return !ref.read(
    proxiesStyleSettingProvider.select((state) => state.showHiddenItems),
  );
}
```

该平台判断避免改变 Windows、Linux 和 Android 原有交互。

### 3. 临时菜单只覆盖本次策略组列表

旧菜单只能使用 `trayState.groups`：

```dart
for (final group in trayState.groups) {
  // ...
}
```

新菜单构建支持一次性的 `groupsOverride`：

```dart
final menuGroups = groupsOverride ?? trayState.groups;
```

Option 点击时从原始 `groupsProvider` 重新计算包含隐藏项的列表，并只传给本次弹出的菜单；不会写入 `ProxiesStyle`，也不会触发 WebDAV 配置变更。

### 4. 避免与正在刷新的托盘菜单竞争

临时弹出前取消防抖计时，并等待当前 `_doUpdate` 完成，再使用同一份 `TrayState` 构建临时菜单，避免并发更新覆盖 Option 菜单。

## 平台与配置边界

- 快捷键逻辑仅在 macOS 生效。
- 不新增持久化字段，不改变现有备份和 WebDAV 同步格式。
- 不改变隐藏组过滤规则，只复用现有 `getVisibleGroups(... showHiddenItems: true)`。

## 验证

- `flutter analyze`：通过。
- `flutter test`：9 项全部通过。
- macOS 自定义构建包实机验证：普通点击、Option 左键、Option 右键以及持久开关开启状态均符合预期。

这是关闭的 #321 拆分出的独立功能 PR。
