### PR TITLE
修复：支持查看 Inline 代理提供者内容

### DIFF
--- a/core/common.go
+++ b/core/common.go
@@ -30,11 +30,12 @@ import (
 )
 
 var (
-	currentConfig *config.Config
-	version       = 0
-	isRunning     = false
-	runLock       sync.Mutex
-	mBatch, _     = batch.New[bool](context.Background(), batch.WithConcurrencyNum[bool](50))
+	currentConfig    *config.Config
+	currentRawConfig *config.RawConfig
+	version          = 0
+	isRunning        = false
+	runLock          sync.Mutex
+	mBatch, _        = batch.New[bool](context.Background(), batch.WithConcurrencyNum[bool](50))
 )
 
 type ExternalProviders []ExternalProvider
@@ -318,6 +319,7 @@ func setupConfig(params *SetupParams) error {
 	if err != nil {
 		return err
 	}
+	currentRawConfig = params.Config
 	hub.ApplyConfig(currentConfig)
 	patchSelectGroup(params.SelectedMap)
 	updateListeners()

--- a/core/hub.go
+++ b/core/hub.go
@@ -18,6 +18,7 @@ import (
 	"github.com/metacubex/mihomo/adapter/outboundgroup"
 	"github.com/metacubex/mihomo/common/observable"
 	"github.com/metacubex/mihomo/common/utils"
+	"github.com/metacubex/mihomo/common/yaml"
 	"github.com/metacubex/mihomo/component/age"
 	"github.com/metacubex/mihomo/component/mmdb"
 	"github.com/metacubex/mihomo/component/resolver"
@@ -432,10 +433,21 @@ func handleParseExternalProviderContent(providerName string, fn func(value strin
 	go func() {
 		runLock.Lock()
 		p, exist := getExternalProvidersRaw()[providerName]
+		rawConfig := currentRawConfig
 		runLock.Unlock()
 
 		if !exist {
 			fn("external provider does not exist")
+			return
+		}
+
+		if p.VehicleType() == cp.Inline {
+			buf, err := marshalInlineProviderContent(rawConfig, providerName)
+			if err != nil {
+				fn(err.Error())
+				return
+			}
+			fn(string(buf))
 			return
 		}
 
@@ -463,6 +475,23 @@ func handleParseExternalProviderContent(providerName string, fn func(value strin
 
 		fn(string(buf))
 	}()
+}
+
+func marshalInlineProviderContent(rawConfig *config.RawConfig, providerName string) ([]byte, error) {
+	if rawConfig == nil {
+		return nil, fmt.Errorf("provider content is empty")
+	}
+
+	rawProvider, exist := rawConfig.ProxyProvider[providerName]
+	if !exist {
+		return nil, fmt.Errorf("provider content is empty")
+	}
+	payload, exist := rawProvider["payload"]
+	if !exist {
+		return nil, fmt.Errorf("provider content is empty")
+	}
+
+	return yaml.Marshal(map[string]any{"proxies": payload})
 }
 
 func handleStartLog() {

--- a/core/hub_test.go
+++ b/core/hub_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/metacubex/mihomo/config"
+)
+
+func TestMarshalInlineProviderContent(t *testing.T) {
+	rawConfig := config.DefaultRawConfig()
+	rawConfig.ProxyProvider = map[string]map[string]any{
+		"Source-Proxies": {
+			"type": "inline",
+			"payload": []map[string]any{
+				{
+					"name":     "测试节点",
+					"type":     "ss",
+					"server":   "203.0.113.10",
+					"port":     443,
+					"cipher":   "aes-128-gcm",
+					"password": "test",
+				},
+			},
+		},
+	}
+
+	content, err := marshalInlineProviderContent(rawConfig, "Source-Proxies")
+	if err != nil {
+		t.Fatalf("序列化 inline provider 失败：%v", err)
+	}
+
+	text := string(content)
+	for _, expected := range []string{"proxies:", "测试节点", "203.0.113.10", "aes-128-gcm"} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("提供者内容缺少 %q：\n%s", expected, text)
+		}
+	}
+}
+
+func TestMarshalInlineProviderContentRejectsMissingPayload(t *testing.T) {
+	rawConfig := config.DefaultRawConfig()
+	rawConfig.ProxyProvider = map[string]map[string]any{
+		"Source-Proxies": {"type": "inline"},
+	}
+
+	if _, err := marshalInlineProviderContent(rawConfig, "Source-Proxies"); err == nil {
+		t.Fatal("缺少 payload 时应返回错误")
+	}
+}


### PR DESCRIPTION
## 功能说明

修复代理提供者内容查看仅支持 HTTP/File、无法查看 Inline 提供者的问题。

Inline provider 没有缓存文件路径，旧逻辑会直接返回 `provider path is empty`。本改动保留最近一次成功应用的原始配置；查看 Inline provider 时，从对应 `proxy-providers.<name>.payload` 生成标准 `proxies:` YAML 内容。

## 使用位置

在 Bettbox 的代理提供者列表中打开任意提供者内容：

- HTTP provider：继续读取下载后的缓存文件。
- File provider：继续读取本地文件。
- Inline provider：直接展示配置中内联的节点内容。

## 行为边界

- 不改变 provider 的加载、更新、健康检查与代理组引用逻辑。
- HTTP/File 仍走原有路径读取逻辑。
- Inline 内容只在用户主动查看 provider 时序列化并返回，不创建临时文件。
- 原始配置仅保存在当前 Core 进程内存中；节点密码等字段的可见范围与原有“查看提供者内容”功能一致，不新增网络接口或后台输出。
- 原始配置解析失败时不会覆盖最近一次成功配置。

## 关键逻辑对比

原逻辑仅接受带文件路径的 provider：

```go
ep, err := toExternalProvider(p)
if err != nil || ep.Path == "" {
    fn("provider path is empty")
    return
}
```

新逻辑先识别 Inline provider，并从原始配置提取 `payload`：

```go
if p.VehicleType() == cp.Inline {
    buf, err := marshalInlineProviderContent(rawConfig, providerName)
    // ...
    fn(string(buf))
    return
}
```

## 验证

- `CGO_ENABLED=0 go test .`（`core`）
- `CGO_ENABLED=0 go build -tags=with_gvisor -o /tmp/bettbox-core-inline-provider-check .`（`core`）
- `go test ./adapter/provider ./config`（`core/Clash.Meta`）
- 新增单元测试覆盖 Inline payload 序列化与 payload 缺失错误。

