### PR TITLE
fix(linux): derive single-instance resources from APP_DEV

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -20,8 +20,10 @@ endif()
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
 set(APPLICATION_ID "com.appshub.bettbox")
+set(APP_DEV "0")
 if(_app_dev_found GREATER -1)
   set(APPLICATION_ID "${APPLICATION_ID}.dev")
+  set(APP_DEV "1")
 endif()
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
@@ -75,6 +77,7 @@ pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
 find_package(X11 REQUIRED)
 
 add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+add_definitions(-DAPP_DEV=${APP_DEV})
 
 # Define the application target. To change its name, change BINARY_NAME above,
 # not the value here, or `flutter run` will no longer work.

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -16,9 +16,10 @@
 
 static int _lock_fd = -1;
 
-static gchar* _get_lock_file_path() {
+static gchar* _get_lock_file_path(gboolean dev) {
   const gchar* user_data_dir = g_get_user_data_dir();
-  return g_build_filename(user_data_dir, "com.appshub.bettbox", "Bettbox.lock", nullptr);
+  const gchar* name = dev ? "BettboxDev.lock" : "Bettbox.lock";
+  return g_build_filename(user_data_dir, "com.appshub.bettbox", name, nullptr);
 }
 
 static gchar* _get_control_socket_path(gboolean dev) {
@@ -28,7 +29,7 @@ static gchar* _get_control_socket_path(gboolean dev) {
 }
 
 static gboolean _try_acquire_instance_lock() {
-  g_autofree gchar* lock_path = _get_lock_file_path();
+  g_autofree gchar* lock_path = _get_lock_file_path(APP_DEV);
   g_autofree gchar* lock_dir = g_path_get_dirname(lock_path);
   g_mkdir_with_parents(lock_dir, 0755);
 
@@ -57,30 +58,27 @@ static gboolean _try_acquire_instance_lock() {
 }
 
 static void _send_control_command(const char* command) {
-  const gboolean dev_modes[] = {TRUE, FALSE};
-  for (size_t i = 0; i < G_N_ELEMENTS(dev_modes); i++) {
-    g_autofree gchar* socket_path = _get_control_socket_path(dev_modes[i]);
+  g_autofree gchar* socket_path = _get_control_socket_path(APP_DEV);
 
-    int client_fd = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (client_fd < 0) {
-      continue;
-    }
-
-    struct sockaddr_un addr;
-    memset(&addr, 0, sizeof(addr));
-    addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
-
-    if (connect(client_fd, (struct sockaddr*)&addr, sizeof(addr)) == 0) {
-      gchar* payload = g_strdup_printf("%s\n", command);
-      ssize_t bytes_written = write(client_fd, payload, strlen(payload));
-      (void)bytes_written; // Suppress unused result warning
-      g_free(payload);
-      close(client_fd);
-      return;
-    }
-    close(client_fd);
+  int client_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (client_fd < 0) {
+    return;
   }
+
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+
+  if (connect(client_fd, (struct sockaddr*)&addr, sizeof(addr)) == 0) {
+    gchar* payload = g_strdup_printf("%s\n", command);
+    ssize_t bytes_written = write(client_fd, payload, strlen(payload));
+    (void)bytes_written; // Suppress unused result warning
+    g_free(payload);
+    close(client_fd);
+    return;
+  }
+  close(client_fd);
 }
 
 // App method channel related


### PR DESCRIPTION
在 1ed0c7bf50871e64bdec7f803c3194bb70f5eb34 中，由于 `linux/my_application.cc` 未读取 `APP_DEV`, 导致 0e8fa130e536ecfd31d85aeb07134a1f89f2bdb3 未能生效