### PR TITLE
修复 Android 批量延迟测试误报并补充失败诊断

### DIFF
--- a/core/constant.go
+++ b/core/constant.go
@@ -143,6 +143,7 @@ type Delay struct {
 	Url   string `json:"url"`
 	Name  string `json:"name"`
 	Value int32  `json:"value"`
+	Error string `json:"error,omitempty"`
 }
 
 type Message struct {

--- a/core/hub.go
+++ b/core/hub.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"core/state"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -246,6 +247,7 @@ func handleAsyncTestDelay(paramsString string, fn func(string)) {
 
 		if proxy == nil {
 			delayData.Value = -1
+			delayData.Error = "proxy_not_found"
 			data, _ := json.Marshal(delayData)
 			fn(string(data))
 			return false, nil
@@ -261,6 +263,7 @@ func handleAsyncTestDelay(paramsString string, fn func(string)) {
 		delay, err := proxy.URLTest(ctx, testUrl, expectedStatus)
 		if err != nil || delay == 0 {
 			delayData.Value = -1
+			delayData.Error = delayFailureCode(err)
 			data, _ := json.Marshal(delayData)
 			fn(string(data))
 			return false, nil
@@ -271,6 +274,30 @@ func handleAsyncTestDelay(paramsString string, fn func(string)) {
 		fn(string(data))
 		return false, nil
 	})
+}
+
+// delayFailureCode intentionally exposes a small fixed vocabulary. Raw network
+// errors can contain hostnames, credentials, or provider-specific details and
+// must not cross the core-to-UI boundary.
+func delayFailureCode(err error) string {
+	if err == nil {
+		return "failed"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "cancelled"
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return "dns"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return "network"
+	}
+	return "failed"
 }
 
 func handleGetConnections() string {

--- a/core/hub_test.go
+++ b/core/hub_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestDelayFailureCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "zero delay without error", want: "failed"},
+		{name: "deadline", err: context.DeadlineExceeded, want: "timeout"},
+		{name: "cancelled", err: context.Canceled, want: "cancelled"},
+		{name: "dns", err: &net.DNSError{}, want: "dns"},
+		{name: "network", err: &net.OpError{}, want: "network"},
+		{name: "unknown", err: errors.New("unexpected"), want: "failed"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := delayFailureCode(test.err); got != test.want {
+				t.Fatalf("delayFailureCode() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/lib/clash/core.dart
+++ b/lib/clash/core.dart
@@ -12,6 +12,13 @@ import 'package:bett_box/state.dart';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart';
 
+class DelayTestResult {
+  const DelayTestResult({required this.delay, this.error});
+
+  final Delay delay;
+  final String? error;
+}
+
 class ClashCore {
   static ClashCore? _instance;
   late ClashHandlerInterface clashInterface;
@@ -39,7 +46,12 @@ class ClashCore {
     if (!await homeDir.exists()) {
       await homeDir.create(recursive: true);
     }
-    const geoFileNameList = [mmdbFileName, geoSiteFileName, asnFileName, bundleMRSFileName];
+    const geoFileNameList = [
+      mmdbFileName,
+      geoSiteFileName,
+      asnFileName,
+      bundleMRSFileName,
+    ];
     try {
       for (final geoFileName in geoFileNameList) {
         final geoFile = File(join(homePath, geoFileName));
@@ -132,18 +144,21 @@ class ClashCore {
           return GroupTypeExtension.valueList.contains(proxy?['type']);
         }),
       ];
-      final groupsRaw = groupNames.map((groupName) {
-        final proxyData = allProxies[groupName] as Map?;
-        if (proxyData == null) return null;
-        final group = Map<String, dynamic>.from(
-          proxyData.cast<String, dynamic>(),
-        );
-        group['all'] = ((group['all'] ?? []) as List)
-            .map((name) => allProxies[name])
-            .whereType<Map<String, dynamic>>()
-            .toList();
-        return group;
-      }).whereType<Map<String, dynamic>>().toList();
+      final groupsRaw = groupNames
+          .map((groupName) {
+            final proxyData = allProxies[groupName] as Map?;
+            if (proxyData == null) return null;
+            final group = Map<String, dynamic>.from(
+              proxyData.cast<String, dynamic>(),
+            );
+            group['all'] = ((group['all'] ?? []) as List)
+                .map((name) => allProxies[name])
+                .whereType<Map<String, dynamic>>()
+                .toList();
+            return group;
+          })
+          .whereType<Map<String, dynamic>>()
+          .toList();
       return groupsRaw.map((e) => Group.fromJson(e)).toList();
     });
   }
@@ -254,22 +269,46 @@ class ClashCore {
     await clashInterface.stopListener();
   }
 
-  Future<Delay> getDelay(String url, String proxyName) async {
+  Future<DelayTestResult> getDelay(String url, String proxyName) async {
     final data = await clashInterface.asyncTestDelay(url, proxyName);
     if (data.isEmpty) {
       throw Exception('Empty delay response');
     }
     try {
-      return Delay.fromJson(json.decode(data));
+      final response = json.decode(data) as Map<String, dynamic>;
+      return DelayTestResult(
+        delay: Delay.fromJson(response),
+        error: _safeDelayError(response['error']),
+      );
     } catch (e) {
       commonPrint.log('Failed to parse delay: $e');
       rethrow;
     }
   }
 
-  Future<Map<String, dynamic>> getConfig(String id, {String? ageSecretKey}) async {
+  String? _safeDelayError(Object? value) {
+    return switch (value) {
+      'timeout' ||
+      'cancelled' ||
+      'dns' ||
+      'network' ||
+      'proxy_not_found' ||
+      'failed' ||
+      'client_timeout' ||
+      'client_error' => value as String,
+      _ => null,
+    };
+  }
+
+  Future<Map<String, dynamic>> getConfig(
+    String id, {
+    String? ageSecretKey,
+  }) async {
     final profilePath = await appPath.getProfilePath(id);
-    final res = await clashInterface.getConfig(profilePath, ageSecretKey: ageSecretKey);
+    final res = await clashInterface.getConfig(
+      profilePath,
+      ageSecretKey: ageSecretKey,
+    );
     if (res.isSuccess) {
       return res.data as Map<String, dynamic>;
     } else {

--- a/lib/clash/interface.dart
+++ b/lib/clash/interface.dart
@@ -402,7 +402,7 @@ abstract class ClashHandlerInterface with ClashInterface {
     return invoke<String>(
       method: ActionMethod.asyncTestDelay,
       data: json.encode(delayParams),
-      timeout: Duration(milliseconds: 6000),
+      timeout: httpTimeoutDuration + delayTestBridgeGraceDuration,
       onTimeout: () {
         return json.encode(Delay(name: proxyName, value: -1, url: url));
       },

--- a/lib/clash/interface.dart
+++ b/lib/clash/interface.dart
@@ -210,10 +210,7 @@ abstract class ClashHandlerInterface with ClashInterface {
 
   @override
   FutureOr<String> validateConfig(String data, {String? ageSecretKey}) {
-    final params = {
-      'data': data,
-      'age-secret-key': ageSecretKey ?? '',
-    };
+    final params = {'data': data, 'age-secret-key': ageSecretKey ?? ''};
     return invoke<String>(
       method: ActionMethod.validateConfig,
       data: json.encode(params),
@@ -222,10 +219,7 @@ abstract class ClashHandlerInterface with ClashInterface {
 
   @override
   FutureOr<String> decryptAgeConfig(String data, String ageSecretKey) {
-    final params = {
-      'data': data,
-      'age-secret-key': ageSecretKey,
-    };
+    final params = {'data': data, 'age-secret-key': ageSecretKey};
     return invoke<String>(
       method: ActionMethod.decryptAgeConfig,
       data: json.encode(params),
@@ -243,10 +237,7 @@ abstract class ClashHandlerInterface with ClashInterface {
 
   @override
   Future<Result> getConfig(String path, {String? ageSecretKey}) async {
-    final params = {
-      'path': path,
-      'age-secret-key': ageSecretKey ?? '',
-    };
+    final params = {'path': path, 'age-secret-key': ageSecretKey ?? ''};
     final res = await invoke<Result>(
       method: ActionMethod.getConfig,
       data: json.encode(params),
@@ -404,7 +395,12 @@ abstract class ClashHandlerInterface with ClashInterface {
       data: json.encode(delayParams),
       timeout: httpTimeoutDuration + delayTestBridgeGraceDuration,
       onTimeout: () {
-        return json.encode(Delay(name: proxyName, value: -1, url: url));
+        return json.encode({
+          'name': proxyName,
+          'value': -1,
+          'url': url,
+          'error': 'client_timeout',
+        });
       },
     );
   }
@@ -436,14 +432,14 @@ abstract class ClashHandlerInterface with ClashInterface {
 
   @override
   Future<Map<String, String>> generateAgeKeyPair() async {
-    final res = await invoke<Map>(
-      method: ActionMethod.generateAgeKeyPair,
-    );
+    final res = await invoke<Map>(method: ActionMethod.generateAgeKeyPair);
     return res.map((key, value) => MapEntry(key.toString(), value.toString()));
   }
 
   @override
-  Future<Result<String>> convertAgeSecretKeyToPublicKey(String secretKey) async {
+  Future<Result<String>> convertAgeSecretKeyToPublicKey(
+    String secretKey,
+  ) async {
     final res = await invoke<Result>(
       method: ActionMethod.convertAgeSecretKeyToPublicKey,
       data: secretKey,

--- a/lib/common/constant.dart
+++ b/lib/common/constant.dart
@@ -24,7 +24,20 @@ final baseInfoEdgeInsets = EdgeInsets.symmetric(
 
 final defaultTextScaleFactor =
     WidgetsBinding.instance.platformDispatcher.textScaleFactor;
-const httpTimeoutDuration = Duration(milliseconds: 5000);
+// URL tests are used for high-latency and UDP-based proxy protocols too.
+// Keep the core deadline below the bridge deadline so a completed core result
+// is never discarded by the Dart side first.
+const httpTimeoutDuration = Duration(seconds: 10);
+const delayTestBridgeGraceDuration = Duration(seconds: 1);
+
+// The core accepts up to 50 concurrent tests. A lower client-side limit avoids
+// queueing requests past the per-request bridge timeout on mobile networks.
+const defaultDelayTestConcurrencyLimit = 16;
+const maxDelayTestConcurrencyLimit = 32;
+
+int normalizeDelayTestConcurrency(int configuredLimit) {
+  return configuredLimit.clamp(1, maxDelayTestConcurrencyLimit).toInt();
+}
 const moreDuration = Duration(milliseconds: 100);
 const animateDuration = Duration(milliseconds: 100);
 const midDuration = Duration(milliseconds: 200);
@@ -69,7 +82,7 @@ double getFloatingBottomBarFABReserveHeight(BuildContext context) {
   return 84.0 - min(viewBottom, 12.0);
 }
 
-const defaultTestUrl = 'https://www.apple.com/library/test/success.html';
+const defaultTestUrl = 'https://www.gstatic.com/generate_204';
 
 // Preset test URLs
 const presetTestUrls = [

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -261,7 +261,7 @@ abstract class ProxiesStyle with _$ProxiesStyle {
     @Default(ProxyCardType.shrink) ProxyCardType cardType,
     @Default(DelayAnimationType.none) DelayAnimationType delayAnimation,
     @Default({}) Map<String, String> iconMap,
-    @Default(250) int concurrencyLimit,
+    @Default(defaultDelayTestConcurrencyLimit) int concurrencyLimit,
     @Default(false) bool showHiddenItems,
   }) = _ProxiesStyle;
 

--- a/lib/models/generated/config.freezed.dart
+++ b/lib/models/generated/config.freezed.dart
@@ -1739,7 +1739,7 @@ return $default(_that.type,_that.sortType,_that.layout,_that.iconStyle,_that.car
 @JsonSerializable()
 
 class _ProxiesStyle implements ProxiesStyle {
-  const _ProxiesStyle({this.type = ProxiesType.tab, this.sortType = ProxiesSortType.none, this.layout = ProxiesLayout.standard, this.iconStyle = ProxiesIconStyle.none, this.cardType = ProxyCardType.shrink, this.delayAnimation = DelayAnimationType.none, final  Map<String, String> iconMap = const {}, this.concurrencyLimit = 250, this.showHiddenItems = false}): _iconMap = iconMap;
+  const _ProxiesStyle({this.type = ProxiesType.tab, this.sortType = ProxiesSortType.none, this.layout = ProxiesLayout.standard, this.iconStyle = ProxiesIconStyle.none, this.cardType = ProxyCardType.shrink, this.delayAnimation = DelayAnimationType.none, final  Map<String, String> iconMap = const {}, this.concurrencyLimit = defaultDelayTestConcurrencyLimit, this.showHiddenItems = false}): _iconMap = iconMap;
   factory _ProxiesStyle.fromJson(Map<String, dynamic> json) => _$ProxiesStyleFromJson(json);
 
 @override@JsonKey() final  ProxiesType type;

--- a/lib/models/generated/config.g.dart
+++ b/lib/models/generated/config.g.dart
@@ -263,7 +263,9 @@ _ProxiesStyle _$ProxiesStyleFromJson(Map<String, dynamic> json) =>
             (k, e) => MapEntry(k, e as String),
           ) ??
           const {},
-      concurrencyLimit: (json['concurrencyLimit'] as num?)?.toInt() ?? 250,
+      concurrencyLimit:
+          (json['concurrencyLimit'] as num?)?.toInt() ??
+          defaultDelayTestConcurrencyLimit,
       showHiddenItems: json['showHiddenItems'] as bool? ?? false,
     );
 

--- a/lib/views/proxies/advanced_settings.dart
+++ b/lib/views/proxies/advanced_settings.dart
@@ -139,12 +139,9 @@ class _NodeExclusionDialogState extends ConsumerState<_NodeExclusionDialog> {
 class _ConcurrencyLimitItem extends ConsumerWidget {
   const _ConcurrencyLimitItem();
 
-  static const _options = [8, 16, 32, 64, 250];
+  static const _options = [4, 8, 16, 32];
 
   String _getDisplayText(int value, BuildContext context) {
-    if (value == 250) {
-      return 'MAX';
-    }
     return '$value';
   }
 

--- a/lib/views/proxies/card.dart
+++ b/lib/views/proxies/card.dart
@@ -37,10 +37,7 @@ class ProxyCard extends StatelessWidget {
   static final Map<String, bool> _emojiMatchCache = {};
 
   static bool _hasEmoji(String name) {
-    return _emojiMatchCache.putIfAbsent(
-      name,
-      () => _emojiRegex.hasMatch(name),
-    );
+    return _emojiMatchCache.putIfAbsent(name, () => _emojiRegex.hasMatch(name));
   }
 
   final String groupName;
@@ -116,15 +113,31 @@ class ProxyCard extends StatelessWidget {
             );
           }
 
-          return GestureDetector(
-            onTap: _handleTestCurrentDelay,
-            child: Text(
-              delay > 0 ? '$delay ms' : 'Timeout',
-              style: context.textTheme.labelSmall?.copyWith(
-                overflow: TextOverflow.ellipsis,
-                color: utils.getDelayColor(delay),
-              ),
-            ),
+          return ListenableBuilder(
+            listenable: delayTestDiagnostics,
+            builder: (_, _) {
+              final state = globalState.appController.getProxyCardState(
+                proxy.name,
+              );
+              final error = delayTestDiagnostics.errorFor(
+                DelayTestTarget(
+                  name: state.proxyName,
+                  url: globalState.appController.getRealTestUrl(
+                    state.testUrl.getSafeValue(testUrl ?? ''),
+                  ),
+                ),
+              );
+              return GestureDetector(
+                onTap: _handleTestCurrentDelay,
+                child: Text(
+                  delay > 0 ? '$delay ms' : getDelayErrorLabel(error),
+                  style: context.textTheme.labelSmall?.copyWith(
+                    overflow: TextOverflow.ellipsis,
+                    color: utils.getDelayColor(delay),
+                  ),
+                ),
+              );
+            },
           );
         },
       ),
@@ -181,10 +194,7 @@ class ProxyCard extends StatelessWidget {
 
     Widget wrapPadding(Widget child) {
       if (showComputedMark) {
-        return Padding(
-          padding: const EdgeInsets.only(right: 28),
-          child: child,
-        );
+        return Padding(padding: const EdgeInsets.only(right: 28), child: child);
       }
       return child;
     }
@@ -212,17 +222,15 @@ class ProxyCard extends StatelessWidget {
 
   bool _isSelectedProxy(WidgetRef ref) {
     return ref.watch(
-      getSelectedProxyNameProvider(groupName).select(
-        (name) => name == proxy.name,
-      ),
+      getSelectedProxyNameProvider(
+        groupName,
+      ).select((name) => name == proxy.name),
     );
   }
 
   bool _isComputedMatch(WidgetRef ref) {
     return ref.watch(
-      getProxyNameProvider(groupName).select(
-        (name) => name == proxy.name,
-      ),
+      getProxyNameProvider(groupName).select((name) => name == proxy.name),
     );
   }
 
@@ -273,8 +281,8 @@ class ProxyCard extends StatelessWidget {
     return Consumer(
       builder: (_, ref, child) {
         final isSelected = _isSelectedProxy(ref);
-        final isComputedMatch = groupType.isComputedSelected &&
-            _isComputedMatch(ref);
+        final isComputedMatch =
+            groupType.isComputedSelected && _isComputedMatch(ref);
         final proxyNameWidget = _buildProxyNameWithIcon(
           context,
           ref,
@@ -339,15 +347,14 @@ class ProxyCard extends StatelessWidget {
                               child: TooltipText(
                                 text: Text(
                                   proxy.type,
-                                  style: context.textTheme.bodySmall
-                                      ?.copyWith(
-                                        overflow: TextOverflow.ellipsis,
-                                        color: context
-                                            .textTheme
-                                            .bodySmall
-                                            ?.color
-                                            ?.opacity80,
-                                      ),
+                                  style: context.textTheme.bodySmall?.copyWith(
+                                    overflow: TextOverflow.ellipsis,
+                                    color: context
+                                        .textTheme
+                                        .bodySmall
+                                        ?.color
+                                        ?.opacity80,
+                                  ),
                                 ),
                               ),
                             ),

--- a/lib/views/proxies/common.dart
+++ b/lib/views/proxies/common.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bett_box/clash/clash.dart';
 import 'package:bett_box/common/common.dart';
 import 'package:bett_box/enum/enum.dart';
@@ -33,6 +35,28 @@ class DelayTestCoordinator extends ChangeNotifier {
 }
 
 final delayTestCoordinator = DelayTestCoordinator();
+
+class DelayTestDiagnostics extends ChangeNotifier {
+  final Map<DelayTestTarget, String> _errors = {};
+
+  String? errorFor(DelayTestTarget target) => _errors[target];
+
+  void update(Delay delay, {String? error}) {
+    final target = DelayTestTarget(name: delay.name, url: delay.url);
+    final failed = delay.value != null && delay.value! <= 0;
+    if (!failed || error == null || error.isEmpty) {
+      if (_errors.remove(target) != null) {
+        notifyListeners();
+      }
+      return;
+    }
+    if (_errors[target] == error) return;
+    _errors[target] = error;
+    notifyListeners();
+  }
+}
+
+final delayTestDiagnostics = DelayTestDiagnostics();
 
 @immutable
 class DelayTestTarget {
@@ -83,7 +107,8 @@ double getItemHeight(ProxyCardType proxyCardType) {
   final baseHeight =
       16 + measure.bodyMediumHeight * 2 + measure.bodySmallHeight + 8 + 4;
   return switch (proxyCardType) {
-    ProxyCardType.expand => baseHeight - measure.bodySmallHeight + measure.labelSmallHeight * 2 + 4,
+    ProxyCardType.expand =>
+      baseHeight - measure.bodySmallHeight + measure.labelSmallHeight * 2 + 4,
     ProxyCardType.shrink => baseHeight,
     ProxyCardType.min => baseHeight - measure.bodyMediumHeight,
   };
@@ -106,11 +131,37 @@ Future<void> proxyDelayTest(Proxy proxy, [String? testUrl]) async {
 Future<Delay> _testProxyDelay(DelayTestTarget target) {
   return _delayTestRequestPool.run(target, () async {
     final appController = globalState.appController;
-    appController.setDelay(Delay(url: target.url, name: target.name, value: 0));
-    final delay = await clashCore.getDelay(target.url, target.name);
+    final pendingDelay = Delay(url: target.url, name: target.name, value: 0);
+    delayTestDiagnostics.update(pendingDelay);
+    appController.setDelay(pendingDelay);
+    late final Delay delay;
+    String? error;
+    try {
+      final result = await clashCore.getDelay(target.url, target.name);
+      delay = result.delay;
+      error = result.error;
+    } on TimeoutException {
+      delay = Delay(url: target.url, name: target.name, value: -1);
+      error = 'client_timeout';
+    } catch (_) {
+      delay = Delay(url: target.url, name: target.name, value: -1);
+      error = 'client_error';
+    }
+    delayTestDiagnostics.update(delay, error: error);
     appController.setDelay(delay);
     return delay;
   });
+}
+
+String getDelayErrorLabel(String? error) {
+  return switch (error) {
+    'dns' => 'DNS error',
+    'network' => 'Connection error',
+    'proxy_not_found' => 'Proxy unavailable',
+    'cancelled' => 'Cancelled',
+    'timeout' || 'client_timeout' => 'Timeout',
+    _ => 'Test failed',
+  };
 }
 
 bool _isNonTestableProxyName(String proxyName) {

--- a/lib/views/proxies/common.dart
+++ b/lib/views/proxies/common.dart
@@ -163,7 +163,9 @@ Future<void> delayTest(
       }
       targets.add(DelayTestTarget(name: name, url: url));
     }
-    final concurrencyLimit = globalState.config.proxiesStyle.concurrencyLimit;
+    final concurrencyLimit = normalizeDelayTestConcurrency(
+      globalState.config.proxiesStyle.concurrencyLimit,
+    );
 
     // 按实际节点和实际测试地址创建任务，避免多个代理组别名重复测速。
     final delayTasks = targets.map((target) {

--- a/test/views/proxies/delay_test_coordinator_test.dart
+++ b/test/views/proxies/delay_test_coordinator_test.dart
@@ -1,10 +1,20 @@
 import 'dart:async';
 
+import 'package:bett_box/common/common.dart';
 import 'package:bett_box/models/models.dart';
 import 'package:bett_box/views/proxies/common.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('caps delay-test concurrency below the core queue limit', () {
+    expect(normalizeDelayTestConcurrency(0), 1);
+    expect(normalizeDelayTestConcurrency(16), 16);
+    expect(
+      normalizeDelayTestConcurrency(250),
+      maxDelayTestConcurrencyLimit,
+    );
+  });
+
   test('shares testing state and rejects overlapping group tests', () async {
     final coordinator = DelayTestCoordinator();
 

--- a/test/views/proxies/delay_test_coordinator_test.dart
+++ b/test/views/proxies/delay_test_coordinator_test.dart
@@ -9,10 +9,7 @@ void main() {
   test('caps delay-test concurrency below the core queue limit', () {
     expect(normalizeDelayTestConcurrency(0), 1);
     expect(normalizeDelayTestConcurrency(16), 16);
-    expect(
-      normalizeDelayTestConcurrency(250),
-      maxDelayTestConcurrencyLimit,
-    );
+    expect(normalizeDelayTestConcurrency(250), maxDelayTestConcurrencyLimit);
   });
 
   test('shares testing state and rejects overlapping group tests', () async {
@@ -112,5 +109,38 @@ void main() {
     );
 
     expect({first, second}, hasLength(2));
+  });
+
+  test('keeps only safe error categories for failed delay tests', () {
+    final diagnostics = DelayTestDiagnostics();
+    const target = DelayTestTarget(
+      name: 'resolved-proxy',
+      url: 'https://example.com/generate_204',
+    );
+
+    diagnostics.update(
+      const Delay(
+        name: 'resolved-proxy',
+        url: 'https://example.com/generate_204',
+        value: -1,
+      ),
+      error: 'dns',
+    );
+    expect(diagnostics.errorFor(target), 'dns');
+    expect(getDelayErrorLabel(diagnostics.errorFor(target)), 'DNS error');
+
+    diagnostics.update(
+      const Delay(
+        name: 'resolved-proxy',
+        url: 'https://example.com/generate_204',
+        value: 120,
+      ),
+    );
+    expect(diagnostics.errorFor(target), isNull);
+  });
+
+  test('maps a local bridge timeout without leaving a pending result', () {
+    expect(getDelayErrorLabel('client_timeout'), 'Timeout');
+    expect(getDelayErrorLabel('client_error'), 'Test failed');
   });
 }


### PR DESCRIPTION
## 背景

Android 端对大量节点执行延迟测试时，界面并发度、核心任务队列和桥接超时之间存在不匹配。部分测试会在真正开始前或等待桥接结果时被统一显示为 Timeout，无法区分真实网络失败与客户端测试路径失败。

## 修改内容

- 将默认测试地址统一为 Gstatic 204，并延长手动延迟测试等待时间。
- 限制批量测试并发度，避免超过核心任务队列承载范围。
- 复用相同节点与测试地址的进行中请求，避免重复测试。
- 核心仅返回固定的失败分类：超时、DNS、网络、代理不存在、取消或通用失败；不向界面传递原始网络错误。
- Flutter 侧在桥接异常时收敛为最终失败结果，避免卡在“测试中”状态。
- 卡片按实际解析后的节点和测试地址展示诊断结果，避免代理组别名与真实节点错配。
- 增加核心失败分类与 Flutter 并发、去重、错误显示的回归测试。

## 验证

- `flutter test test/views/proxies/delay_test_coordinator_test.dart`
- `dart analyze`（本次涉及的 Dart 文件）
- `go test .`（core）
- Android arm64 debug APK 构建成功，并完成 APK 签名和架构校验。

## 隐私与范围

本 PR 不包含订阅链接、配置文件、节点信息、日志、APK、设备信息或任何凭据。