### PR TITLE
端口冲突与网络检测优化

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -54,6 +54,13 @@ android {
             isMinifyEnabled = false
             applicationIdSuffix = ".debug"
         }
+        getByName("profile") {
+            // Keep the test package separate from the official release while
+            // using Flutter's AOT/profile runtime instead of debug JIT.
+            applicationIdSuffix = ".test"
+            versionNameSuffix = "-test"
+            signingConfig = signingConfigs.getByName("debug")
+        }
         release {
             isMinifyEnabled = true
             isDebuggable = false

--- a/android/core/build.gradle.kts
+++ b/android/core/build.gradle.kts
@@ -49,10 +49,16 @@ dependencies {
 }
 
 val copyNativeLibs by tasks.register<Copy>("copyNativeLibs") {
+    val nativeLibsSource = file("../../libclash/android")
     doFirst {
+        check(nativeLibsSource.isDirectory && nativeLibsSource.walkTopDown().any {
+            it.isFile && it.name == "libclash.so"
+        }) {
+            "Android core library is missing. Generate libclash before packaging the APK."
+        }
         delete("src/main/jniLibs")
     }
-    from("../../libclash/android")
+    from(nativeLibsSource)
     into("src/main/jniLibs")
 }
 

--- a/core/common.go
+++ b/core/common.go
@@ -304,14 +304,7 @@ func setupConfig(params *SetupParams) error {
 		}
 	}
 
-	constant.DefaultTestURL = params.TestURL
-	if params.OverrideTestUrl && params.Config != nil {
-		if params.Config.ProxyGroup != nil {
-			for _, group := range params.Config.ProxyGroup {
-				group["url"] = params.TestURL
-			}
-		}
-	}
+	applyTestURLOverride(params)
 
 	var err error
 	currentConfig, err = config.ParseRawConfig(params.Config)
@@ -324,6 +317,28 @@ func setupConfig(params *SetupParams) error {
 	runtime.GC()
 	debug.FreeOSMemory()
 	return nil
+}
+
+func applyTestURLOverride(params *SetupParams) {
+	constant.DefaultTestURL = params.TestURL
+	if !params.OverrideTestUrl || params.Config == nil {
+		return
+	}
+
+	for _, group := range params.Config.ProxyGroup {
+		group["url"] = params.TestURL
+	}
+
+	// Keep provider health checks aligned with the test URL selected in the
+	// app. Only update an existing health-check section: an override must not
+	// enable health checks for providers that did not opt into them.
+	for _, provider := range params.Config.ProxyProvider {
+		healthCheck, ok := provider["health-check"].(map[string]any)
+		if !ok {
+			continue
+		}
+		healthCheck["url"] = params.TestURL
+	}
 }
 
 func UnmarshalJson(data []byte, v any) error {

--- a/core/delay_failure_test.go
+++ b/core/delay_failure_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/metacubex/mihomo/config"
+)
+
+func TestDelayFailureValue(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int32
+	}{
+		{name: "timeout", err: context.DeadlineExceeded, want: delayFailureTimeout},
+		{name: "dns", err: errors.New("lookup host: no such host"), want: delayFailureDNS},
+		{name: "tls", err: errors.New("tls handshake failed"), want: delayFailureTLS},
+		{name: "http", err: errors.New("unexpected HTTP status"), want: delayFailureHTTP},
+		{name: "connect", err: errors.New("connect: connection refused"), want: delayFailureConnect},
+		{name: "unknown", err: fmt.Errorf("unexpected result"), want: delayFailureUnknown},
+		{name: "empty response", err: nil, want: delayFailureUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := delayFailureValue(tt.err); got != tt.want {
+				t.Fatalf("delayFailureValue() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyTestURLOverride(t *testing.T) {
+	selectedURL := "https://test.example/generate_204"
+	params := &SetupParams{
+		TestURL:         selectedURL,
+		OverrideTestUrl: true,
+		Config: &config.RawConfig{
+			ProxyGroup: []map[string]any{{"url": "https://group.example"}},
+			ProxyProvider: map[string]map[string]any{
+				"with-health-check": {
+					"health-check": map[string]any{"url": "https://provider.example"},
+				},
+				"without-health-check": {"type": "http"},
+			},
+		},
+	}
+
+	applyTestURLOverride(params)
+
+	if got := params.Config.ProxyGroup[0]["url"]; got != selectedURL {
+		t.Fatalf("group URL = %v, want %s", got, selectedURL)
+	}
+	healthCheck := params.Config.ProxyProvider["with-health-check"]["health-check"].(map[string]any)
+	if got := healthCheck["url"]; got != selectedURL {
+		t.Fatalf("provider health-check URL = %v, want %s", got, selectedURL)
+	}
+	if _, ok := params.Config.ProxyProvider["without-health-check"]["health-check"]; ok {
+		t.Fatal("override must not create a missing provider health-check")
+	}
+}

--- a/core/hub.go
+++ b/core/hub.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"core/state"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"runtime/debug"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/metacubex/mihomo/adapter"
@@ -245,7 +247,7 @@ func handleAsyncTestDelay(paramsString string, fn func(string)) {
 		}
 
 		if proxy == nil {
-			delayData.Value = -1
+			delayData.Value = delayFailureProxyNotFound
 			data, _ := json.Marshal(delayData)
 			fn(string(data))
 			return false, nil
@@ -260,7 +262,7 @@ func handleAsyncTestDelay(paramsString string, fn func(string)) {
 
 		delay, err := proxy.URLTest(ctx, testUrl, expectedStatus)
 		if err != nil || delay == 0 {
-			delayData.Value = -1
+			delayData.Value = delayFailureValue(err)
 			data, _ := json.Marshal(delayData)
 			fn(string(data))
 			return false, nil
@@ -271,6 +273,55 @@ func handleAsyncTestDelay(paramsString string, fn func(string)) {
 		fn(string(data))
 		return false, nil
 	})
+}
+
+const (
+	delayFailureTimeout       int32 = -1
+	delayFailureProxyNotFound int32 = -2
+	delayFailureDNS           int32 = -3
+	delayFailureTLS           int32 = -4
+	delayFailureHTTP          int32 = -5
+	delayFailureConnect       int32 = -6
+	delayFailureUnknown       int32 = -7
+)
+
+// delayFailureValue returns a stable, non-sensitive category for the UI.
+// Do not return raw errors here: they can include hostnames or credentials.
+func delayFailureValue(err error) int32 {
+	if err == nil {
+		return delayFailureUnknown
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return delayFailureTimeout
+	}
+	var networkErr net.Error
+	if errors.As(err, &networkErr) && networkErr.Timeout() {
+		return delayFailureTimeout
+	}
+
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "no such host"),
+		strings.Contains(message, "dns"),
+		strings.Contains(message, "lookup"):
+		return delayFailureDNS
+	case strings.Contains(message, "tls"),
+		strings.Contains(message, "x509"),
+		strings.Contains(message, "certificate"),
+		strings.Contains(message, "handshake"):
+		return delayFailureTLS
+	case strings.Contains(message, "status"),
+		strings.Contains(message, "http"):
+		return delayFailureHTTP
+	case strings.Contains(message, "connect"),
+		strings.Contains(message, "connection"),
+		strings.Contains(message, "network is unreachable"),
+		strings.Contains(message, "no route"),
+		strings.Contains(message, "refused"):
+		return delayFailureConnect
+	default:
+		return delayFailureUnknown
+	}
 }
 
 func handleGetConnections() string {

--- a/lib/clash/interface.dart
+++ b/lib/clash/interface.dart
@@ -210,10 +210,7 @@ abstract class ClashHandlerInterface with ClashInterface {
 
   @override
   FutureOr<String> validateConfig(String data, {String? ageSecretKey}) {
-    final params = {
-      'data': data,
-      'age-secret-key': ageSecretKey ?? '',
-    };
+    final params = {'data': data, 'age-secret-key': ageSecretKey ?? ''};
     return invoke<String>(
       method: ActionMethod.validateConfig,
       data: json.encode(params),
@@ -222,10 +219,7 @@ abstract class ClashHandlerInterface with ClashInterface {
 
   @override
   FutureOr<String> decryptAgeConfig(String data, String ageSecretKey) {
-    final params = {
-      'data': data,
-      'age-secret-key': ageSecretKey,
-    };
+    final params = {'data': data, 'age-secret-key': ageSecretKey};
     return invoke<String>(
       method: ActionMethod.decryptAgeConfig,
       data: json.encode(params),
@@ -243,10 +237,7 @@ abstract class ClashHandlerInterface with ClashInterface {
 
   @override
   Future<Result> getConfig(String path, {String? ageSecretKey}) async {
-    final params = {
-      'path': path,
-      'age-secret-key': ageSecretKey ?? '',
-    };
+    final params = {'path': path, 'age-secret-key': ageSecretKey ?? ''};
     final res = await invoke<Result>(
       method: ActionMethod.getConfig,
       data: json.encode(params),
@@ -402,9 +393,11 @@ abstract class ClashHandlerInterface with ClashInterface {
     return invoke<String>(
       method: ActionMethod.asyncTestDelay,
       data: json.encode(delayParams),
-      timeout: Duration(milliseconds: 6000),
+      timeout: httpTimeoutDuration + delayTestBridgeGraceDuration,
       onTimeout: () {
-        return json.encode(Delay(name: proxyName, value: -1, url: url));
+        return json.encode(
+          Delay(name: proxyName, value: delayBridgeTimeoutValue, url: url),
+        );
       },
     );
   }
@@ -436,14 +429,14 @@ abstract class ClashHandlerInterface with ClashInterface {
 
   @override
   Future<Map<String, String>> generateAgeKeyPair() async {
-    final res = await invoke<Map>(
-      method: ActionMethod.generateAgeKeyPair,
-    );
+    final res = await invoke<Map>(method: ActionMethod.generateAgeKeyPair);
     return res.map((key, value) => MapEntry(key.toString(), value.toString()));
   }
 
   @override
-  Future<Result<String>> convertAgeSecretKeyToPublicKey(String secretKey) async {
+  Future<Result<String>> convertAgeSecretKeyToPublicKey(
+    String secretKey,
+  ) async {
     final res = await invoke<Result>(
       method: ActionMethod.convertAgeSecretKeyToPublicKey,
       data: secretKey,

--- a/lib/common/constant.dart
+++ b/lib/common/constant.dart
@@ -24,7 +24,44 @@ final baseInfoEdgeInsets = EdgeInsets.symmetric(
 
 final defaultTextScaleFactor =
     WidgetsBinding.instance.platformDispatcher.textScaleFactor;
-const httpTimeoutDuration = Duration(milliseconds: 5000);
+// URL tests are used for high-latency and UDP-based proxy protocols too.
+// Keep the core deadline below the bridge deadline so a completed core result
+// is never discarded by the Dart side first.
+const httpTimeoutDuration = Duration(seconds: 10);
+const delayTestBridgeGraceDuration = Duration(seconds: 1);
+
+const delayTestingValue = 0;
+const delayTimeoutValue = -1;
+const delayProxyNotFoundValue = -2;
+const delayDnsFailureValue = -3;
+const delayTlsFailureValue = -4;
+const delayHttpFailureValue = -5;
+const delayConnectFailureValue = -6;
+const delayUnknownFailureValue = -7;
+const delayBridgeTimeoutValue = -8;
+
+String delayFailureLabel(int value) {
+  return switch (value) {
+    delayTimeoutValue => 'Timeout',
+    delayProxyNotFoundValue => 'Unavailable',
+    delayDnsFailureValue => 'DNS',
+    delayTlsFailureValue => 'TLS',
+    delayHttpFailureValue => 'HTTP',
+    delayConnectFailureValue => 'Connect',
+    delayBridgeTimeoutValue => 'App timeout',
+    _ => 'Failed',
+  };
+}
+
+// The core accepts up to 50 concurrent tests. A lower client-side limit avoids
+// queueing requests past the per-request bridge timeout on mobile networks.
+const defaultDelayTestConcurrencyLimit = 16;
+const maxDelayTestConcurrencyLimit = 32;
+
+int normalizeDelayTestConcurrency(int configuredLimit) {
+  return configuredLimit.clamp(1, maxDelayTestConcurrencyLimit).toInt();
+}
+
 const moreDuration = Duration(milliseconds: 100);
 const animateDuration = Duration(milliseconds: 100);
 const midDuration = Duration(milliseconds: 200);
@@ -69,7 +106,7 @@ double getFloatingBottomBarFABReserveHeight(BuildContext context) {
   return 84.0 - min(viewBottom, 12.0);
 }
 
-const defaultTestUrl = 'https://www.apple.com/library/test/success.html';
+const defaultTestUrl = 'https://www.gstatic.com/generate_204';
 
 // Preset test URLs
 const presetTestUrls = [

--- a/lib/common/http.dart
+++ b/lib/common/http.dart
@@ -8,7 +8,7 @@ class BettboxHttpOverrides extends HttpOverrides {
     if ([localhost].contains(url.host)) {
       return 'DIRECT';
     }
-    final port = globalState.config.patchClashConfig.mixedPort;
+    final port = globalState.effectiveMixedPort;
     final isStart = globalState.appState.runTime != null;
     if (!isStart) return 'DIRECT';
     return 'PROXY localhost:$port';

--- a/lib/common/local_port.dart
+++ b/lib/common/local_port.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+Future<bool> isLocalPortAvailable(int port, {bool allowLan = false}) async {
+  if (port <= 0 || port > 65535) return false;
+
+  ServerSocket? socket;
+  try {
+    socket = await ServerSocket.bind(
+      allowLan ? InternetAddress.anyIPv4 : InternetAddress.loopbackIPv4,
+      port,
+      shared: false,
+    );
+    return true;
+  } on SocketException {
+    return false;
+  } finally {
+    await socket?.close();
+  }
+}
+
+Future<int> findAvailableLocalPort(
+  int preferred, {
+  bool allowLan = false,
+  int scanLimit = 20,
+}) async {
+  if (preferred <= 0) return preferred;
+
+  for (var offset = 0; offset <= scanLimit; offset++) {
+    final candidate = preferred + offset;
+    if (candidate > 65535) break;
+    if (await isLocalPortAvailable(candidate, allowLan: allowLan)) {
+      return candidate;
+    }
+  }
+
+  ServerSocket? socket;
+  try {
+    socket = await ServerSocket.bind(
+      allowLan ? InternetAddress.anyIPv4 : InternetAddress.loopbackIPv4,
+      0,
+      shared: false,
+    );
+    return socket.port;
+  } finally {
+    await socket?.close();
+  }
+}

--- a/lib/common/request.dart
+++ b/lib/common/request.dart
@@ -57,9 +57,7 @@ class Request {
       }
     }
 
-    final headers = <String, dynamic>{
-      'Connection': 'close',
-    };
+    final headers = <String, dynamic>{'Connection': 'close'};
     if (userInfo != null && userInfo.isNotEmpty) {
       final auth = base64Encode(utf8.encode(userInfo));
       headers['Authorization'] = 'Basic $auth';
@@ -67,10 +65,7 @@ class Request {
 
     final response = await _clashDio.get(
       requestUrl,
-      options: Options(
-        responseType: responseType,
-        headers: headers,
-      ),
+      options: Options(responseType: responseType, headers: headers),
     );
     return response;
   }
@@ -153,6 +148,18 @@ class Request {
         connectTimeout: effectiveTimeout,
       ),
     );
+    if (system.isAndroid) {
+      // Android VPN/TUN already captures this socket. Bypassing the local
+      // Mixed port prevents IP detection from depending on a second local
+      // listener when another Bettbox instance owns the preferred port.
+      dio.httpClientAdapter = IOHttpClientAdapter(
+        createHttpClient: () {
+          final client = HttpClient();
+          client.findProxy = (_) => 'DIRECT';
+          return client;
+        },
+      );
+    }
 
     final Completer<Result<IpInfo?>> resultCompleter = Completer();
     int failureCount = 0;

--- a/lib/common/runtime_config_overrides.dart
+++ b/lib/common/runtime_config_overrides.dart
@@ -1,0 +1,23 @@
+void applyProviderHealthCheckTimeoutOverride(
+  Map<String, dynamic> rawConfig,
+  int timeout,
+) {
+  if (timeout == 5000) {
+    return;
+  }
+
+  final providers = rawConfig['proxy-providers'];
+  if (providers is! Map) {
+    return;
+  }
+
+  for (final provider in providers.values) {
+    if (provider is! Map) {
+      continue;
+    }
+    final healthCheck = provider['health-check'];
+    if (healthCheck is Map) {
+      healthCheck['timeout'] ??= timeout;
+    }
+  }
+}

--- a/lib/models/common.dart
+++ b/lib/models/common.dart
@@ -457,8 +457,10 @@ class IpInfo {
       }
     }
 
-    if (ip != null && countryCode != null) {
-      return IpInfo(ip: ip, countryCode: countryCode);
+    if (ip != null && ip.isNotEmpty) {
+      // The IP is still useful when a trace endpoint omits the optional
+      // location field or returns it in a format that cannot be mapped.
+      return IpInfo(ip: ip, countryCode: countryCode ?? '');
     }
 
     throw const FormatException('invalid cloudflare trace format');
@@ -541,8 +543,12 @@ abstract class Result<T> with _$Result<T> {
     @Default(false) bool needRestart,
   }) = _Result;
 
-  factory Result.success(T data, {bool needRestart = false}) =>
-      Result(data: data, type: ResultType.success, message: '', needRestart: needRestart);
+  factory Result.success(T data, {bool needRestart = false}) => Result(
+    data: data,
+    type: ResultType.success,
+    message: '',
+    needRestart: needRestart,
+  );
 
   factory Result.error(String message) =>
       Result(data: null, type: ResultType.error, message: message);
@@ -564,7 +570,11 @@ abstract class Script with _$Script {
     @JsonKey(name: 'custom-options') Map<String, bool>? customOptions,
   }) = _Script;
 
-  factory Script.create({required String label, required String content, String? url}) {
+  factory Script.create({
+    required String label,
+    required String content,
+    String? url,
+  }) {
     return Script(id: utils.uuidV4, label: label, content: content, url: url);
   }
 

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -261,7 +261,7 @@ abstract class ProxiesStyle with _$ProxiesStyle {
     @Default(ProxyCardType.shrink) ProxyCardType cardType,
     @Default(DelayAnimationType.none) DelayAnimationType delayAnimation,
     @Default({}) Map<String, String> iconMap,
-    @Default(250) int concurrencyLimit,
+    @Default(defaultDelayTestConcurrencyLimit) int concurrencyLimit,
     @Default(false) bool showHiddenItems,
   }) = _ProxiesStyle;
 

--- a/lib/models/generated/config.freezed.dart
+++ b/lib/models/generated/config.freezed.dart
@@ -1739,7 +1739,7 @@ return $default(_that.type,_that.sortType,_that.layout,_that.iconStyle,_that.car
 @JsonSerializable()
 
 class _ProxiesStyle implements ProxiesStyle {
-  const _ProxiesStyle({this.type = ProxiesType.tab, this.sortType = ProxiesSortType.none, this.layout = ProxiesLayout.standard, this.iconStyle = ProxiesIconStyle.none, this.cardType = ProxyCardType.shrink, this.delayAnimation = DelayAnimationType.none, final  Map<String, String> iconMap = const {}, this.concurrencyLimit = 250, this.showHiddenItems = false}): _iconMap = iconMap;
+const _ProxiesStyle({this.type = ProxiesType.tab, this.sortType = ProxiesSortType.none, this.layout = ProxiesLayout.standard, this.iconStyle = ProxiesIconStyle.none, this.cardType = ProxyCardType.shrink, this.delayAnimation = DelayAnimationType.none, final  Map<String, String> iconMap = const {}, this.concurrencyLimit = defaultDelayTestConcurrencyLimit, this.showHiddenItems = false}): _iconMap = iconMap;
   factory _ProxiesStyle.fromJson(Map<String, dynamic> json) => _$ProxiesStyleFromJson(json);
 
 @override@JsonKey() final  ProxiesType type;

--- a/lib/models/generated/config.g.dart
+++ b/lib/models/generated/config.g.dart
@@ -263,7 +263,7 @@ _ProxiesStyle _$ProxiesStyleFromJson(Map<String, dynamic> json) =>
             (k, e) => MapEntry(k, e as String),
           ) ??
           const {},
-      concurrencyLimit: (json['concurrencyLimit'] as num?)?.toInt() ?? 250,
+concurrencyLimit: (json['concurrencyLimit'] as num?)?.toInt() ?? defaultDelayTestConcurrencyLimit,
       showHiddenItems: json['showHiddenItems'] as bool? ?? false,
     );
 

--- a/lib/providers/state.dart
+++ b/lib/providers/state.dart
@@ -180,9 +180,7 @@ ProxyState proxyState(Ref ref) {
       (state) => VM2(a: state.systemProxy, b: state.bypassDomain),
     ),
   );
-  final mixedPort = ref.watch(
-    patchClashConfigProvider.select((state) => state.mixedPort),
-  );
+  final mixedPort = globalState.effectiveMixedPort;
   return ProxyState(
     isStart: isStart,
     systemProxy: vm2.a,

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -23,6 +23,8 @@ import 'package:synchronized/synchronized.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'common/common.dart';
+import 'common/local_port.dart';
+import 'common/runtime_config_overrides.dart';
 import 'controller.dart';
 import 'models/models.dart';
 
@@ -59,6 +61,8 @@ class GlobalState {
   Timer? _backgroundCleanupTimer;
   final Lock _scriptEvaluateLock = Lock();
   bool isInit = false;
+  int? _runtimeMixedPort;
+  int? _runtimeMixedPortPreference;
 
   bool get isStart => startTime != null && startTime!.isBeforeNow;
 
@@ -120,7 +124,8 @@ class GlobalState {
 
   Future<void> init() async {
     packageInfo = await PackageInfo.fromPlatform();
-    config = await preferences.getConfig() ??
+    config =
+        await preferences.getConfig() ??
         Config(
           themeProps: defaultThemeProps,
           patchClashConfig: system.isAndroid
@@ -140,6 +145,34 @@ class GlobalState {
   bool get isAndroidTV => _isAndroidTV ?? false;
 
   String get ua => config.patchClashConfig.globalUa ?? packageInfo.ua;
+
+  int get effectiveMixedPort =>
+      _runtimeMixedPort ?? config.patchClashConfig.mixedPort;
+
+  Future<int> resolveMixedPort(int preferred, {required bool allowLan}) async {
+    if (!system.isAndroid || preferred <= 0) return preferred;
+    if (_runtimeMixedPortPreference == preferred && _runtimeMixedPort != null) {
+      return _runtimeMixedPort!;
+    }
+
+    final resolved = await findAvailableLocalPort(
+      preferred,
+      allowLan: allowLan,
+    );
+    _runtimeMixedPortPreference = preferred;
+    _runtimeMixedPort = resolved;
+    if (resolved != preferred) {
+      commonPrint.log(
+        '[Mixed] Port $preferred is busy; using local port $resolved',
+      );
+    }
+    return resolved;
+  }
+
+  void resetRuntimeMixedPort() {
+    _runtimeMixedPort = null;
+    _runtimeMixedPortPreference = null;
+  }
 
   Future<void> startUpdateTasks([UpdateTasks? tasks]) async {
     if (tasks != null) {
@@ -339,6 +372,7 @@ class GlobalState {
     } else {
       await clashCore.stopListener();
     }
+    resetRuntimeMixedPort();
     if (!includeVpnService) {
       stopUpdateTasks();
       return;
@@ -463,10 +497,7 @@ class GlobalState {
                       color: Theme.of(context).colorScheme.surface,
                       borderRadius: BorderRadius.circular(28),
                       boxShadow: const [
-                        BoxShadow(
-                          blurRadius: 10,
-                          color: Colors.black12,
-                        ),
+                        BoxShadow(blurRadius: 10, color: Colors.black12),
                       ],
                     ),
                     child: const Column(
@@ -599,7 +630,10 @@ class GlobalState {
     rawConfig['port'] = 0;
     rawConfig['socks-port'] = 0;
     rawConfig['keep-alive-interval'] = realPatchConfig.keepAliveInterval;
-    rawConfig['mixed-port'] = realPatchConfig.mixedPort;
+    rawConfig['mixed-port'] = await resolveMixedPort(
+      realPatchConfig.mixedPort,
+      allowLan: realPatchConfig.allowLan,
+    );
     rawConfig['port'] = realPatchConfig.port;
     rawConfig['socks-port'] = realPatchConfig.socksPort;
     rawConfig['redir-port'] = realPatchConfig.redirPort;
@@ -768,6 +802,7 @@ class GlobalState {
 
     final nodeExcludeFilter = globalState.config.nodeExcludeFilter;
     final healthCheckTimeout = globalState.config.healthCheckTimeout;
+    applyProviderHealthCheckTimeoutOverride(rawConfig, healthCheckTimeout);
     if ((nodeExcludeFilter.isNotEmpty || healthCheckTimeout != 5000) &&
         rawConfig['proxy-groups'] is List) {
       RegExp? filterRegex;
@@ -862,8 +897,8 @@ class GlobalState {
       rawConfig.remove('rule');
     }
 
-    final scriptActive = config.scriptProps.currentScript != null &&
-        profile.useScriptOverride;
+    final scriptActive =
+        config.scriptProps.currentScript != null && profile.useScriptOverride;
 
     final overrideData = profile.overrideData;
     if (overrideData.enable && !scriptActive) {
@@ -1150,9 +1185,11 @@ class DetectionState {
   }
 
   void tryStartCheck() {
-    if (!state.value.isLoading &&
-        state.value.ipInfo == null &&
-        (_preIsStart == null || state.value.errorMessage != null)) {
+    final isFirstAttempt = _requestId == 0;
+    if (isFirstAttempt ||
+        (!state.value.isLoading &&
+            state.value.ipInfo == null &&
+            (_preIsStart == null || state.value.errorMessage != null))) {
       startCheck();
     }
   }

--- a/lib/views/proxies/advanced_settings.dart
+++ b/lib/views/proxies/advanced_settings.dart
@@ -139,12 +139,9 @@ class _NodeExclusionDialogState extends ConsumerState<_NodeExclusionDialog> {
 class _ConcurrencyLimitItem extends ConsumerWidget {
   const _ConcurrencyLimitItem();
 
-  static const _options = [8, 16, 32, 64, 250];
+  static const _options = [4, 8, 16, 32];
 
   String _getDisplayText(int value, BuildContext context) {
-    if (value == 250) {
-      return 'MAX';
-    }
     return '$value';
   }
 

--- a/lib/views/proxies/card.dart
+++ b/lib/views/proxies/card.dart
@@ -37,10 +37,7 @@ class ProxyCard extends StatelessWidget {
   static final Map<String, bool> _emojiMatchCache = {};
 
   static bool _hasEmoji(String name) {
-    return _emojiMatchCache.putIfAbsent(
-      name,
-      () => _emojiRegex.hasMatch(name),
-    );
+    return _emojiMatchCache.putIfAbsent(name, () => _emojiRegex.hasMatch(name));
   }
 
   final String groupName;
@@ -89,7 +86,7 @@ class ProxyCard extends StatelessWidget {
             return const SizedBox(height: 0, width: 0);
           }
 
-          if (delay == 0) {
+          if (delay == delayTestingValue) {
             return SizedBox(
               height: measure.labelSmallHeight,
               width: measure.labelSmallHeight,
@@ -116,13 +113,17 @@ class ProxyCard extends StatelessWidget {
             );
           }
 
+          final label = delay > 0 ? '$delay ms' : delayFailureLabel(delay);
           return GestureDetector(
             onTap: _handleTestCurrentDelay,
-            child: Text(
-              delay > 0 ? '$delay ms' : 'Timeout',
-              style: context.textTheme.labelSmall?.copyWith(
-                overflow: TextOverflow.ellipsis,
-                color: utils.getDelayColor(delay),
+            child: Tooltip(
+              message: delay > 0 ? appLocalizations.delay : label,
+              child: Text(
+                label,
+                style: context.textTheme.labelSmall?.copyWith(
+                  overflow: TextOverflow.ellipsis,
+                  color: utils.getDelayColor(delay),
+                ),
               ),
             ),
           );
@@ -181,10 +182,7 @@ class ProxyCard extends StatelessWidget {
 
     Widget wrapPadding(Widget child) {
       if (showComputedMark) {
-        return Padding(
-          padding: const EdgeInsets.only(right: 28),
-          child: child,
-        );
+        return Padding(padding: const EdgeInsets.only(right: 28), child: child);
       }
       return child;
     }
@@ -212,17 +210,15 @@ class ProxyCard extends StatelessWidget {
 
   bool _isSelectedProxy(WidgetRef ref) {
     return ref.watch(
-      getSelectedProxyNameProvider(groupName).select(
-        (name) => name == proxy.name,
-      ),
+      getSelectedProxyNameProvider(
+        groupName,
+      ).select((name) => name == proxy.name),
     );
   }
 
   bool _isComputedMatch(WidgetRef ref) {
     return ref.watch(
-      getProxyNameProvider(groupName).select(
-        (name) => name == proxy.name,
-      ),
+      getProxyNameProvider(groupName).select((name) => name == proxy.name),
     );
   }
 
@@ -273,8 +269,8 @@ class ProxyCard extends StatelessWidget {
     return Consumer(
       builder: (_, ref, child) {
         final isSelected = _isSelectedProxy(ref);
-        final isComputedMatch = groupType.isComputedSelected &&
-            _isComputedMatch(ref);
+        final isComputedMatch =
+            groupType.isComputedSelected && _isComputedMatch(ref);
         final proxyNameWidget = _buildProxyNameWithIcon(
           context,
           ref,
@@ -339,15 +335,14 @@ class ProxyCard extends StatelessWidget {
                               child: TooltipText(
                                 text: Text(
                                   proxy.type,
-                                  style: context.textTheme.bodySmall
-                                      ?.copyWith(
-                                        overflow: TextOverflow.ellipsis,
-                                        color: context
-                                            .textTheme
-                                            .bodySmall
-                                            ?.color
-                                            ?.opacity80,
-                                      ),
+                                  style: context.textTheme.bodySmall?.copyWith(
+                                    overflow: TextOverflow.ellipsis,
+                                    color: context
+                                        .textTheme
+                                        .bodySmall
+                                        ?.color
+                                        ?.opacity80,
+                                  ),
                                 ),
                               ),
                             ),

--- a/lib/views/proxies/common.dart
+++ b/lib/views/proxies/common.dart
@@ -83,7 +83,8 @@ double getItemHeight(ProxyCardType proxyCardType) {
   final baseHeight =
       16 + measure.bodyMediumHeight * 2 + measure.bodySmallHeight + 8 + 4;
   return switch (proxyCardType) {
-    ProxyCardType.expand => baseHeight - measure.bodySmallHeight + measure.labelSmallHeight * 2 + 4,
+    ProxyCardType.expand =>
+      baseHeight - measure.bodySmallHeight + measure.labelSmallHeight * 2 + 4,
     ProxyCardType.shrink => baseHeight,
     ProxyCardType.min => baseHeight - measure.bodyMediumHeight,
   };
@@ -106,7 +107,9 @@ Future<void> proxyDelayTest(Proxy proxy, [String? testUrl]) async {
 Future<Delay> _testProxyDelay(DelayTestTarget target) {
   return _delayTestRequestPool.run(target, () async {
     final appController = globalState.appController;
-    appController.setDelay(Delay(url: target.url, name: target.name, value: 0));
+    appController.setDelay(
+      Delay(url: target.url, name: target.name, value: delayTestingValue),
+    );
     final delay = await clashCore.getDelay(target.url, target.name);
     appController.setDelay(delay);
     return delay;
@@ -163,7 +166,9 @@ Future<void> delayTest(
       }
       targets.add(DelayTestTarget(name: name, url: url));
     }
-    final concurrencyLimit = globalState.config.proxiesStyle.concurrencyLimit;
+    final concurrencyLimit = normalizeDelayTestConcurrency(
+      globalState.config.proxiesStyle.concurrencyLimit,
+    );
 
     // 按实际节点和实际测试地址创建任务，避免多个代理组别名重复测速。
     final delayTasks = targets.map((target) {

--- a/test/common/local_port_test.dart
+++ b/test/common/local_port_test.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:bett_box/common/local_port.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'selects another local port when the preferred port is occupied',
+    () async {
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      try {
+        final selected = await findAvailableLocalPort(server.port);
+        expect(selected, isNot(server.port));
+      } finally {
+        await server.close();
+      }
+    },
+  );
+
+  test('keeps port zero disabled', () async {
+    expect(await findAvailableLocalPort(0), 0);
+  });
+}

--- a/test/common/runtime_config_overrides_test.dart
+++ b/test/common/runtime_config_overrides_test.dart
@@ -1,0 +1,40 @@
+import 'package:bett_box/common/runtime_config_overrides.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('updates the timeout of existing provider health checks only', () {
+    final rawConfig = <String, dynamic>{
+      'proxy-providers': {
+        'with-health-check': {
+          'health-check': <String, dynamic>{'url': 'https://test.invalid'},
+        },
+        'without-health-check': <String, dynamic>{'type': 'http'},
+      },
+    };
+
+    applyProviderHealthCheckTimeoutOverride(rawConfig, 8000);
+
+    final providers = rawConfig['proxy-providers'] as Map;
+    final enabled = providers['with-health-check'] as Map;
+    expect((enabled['health-check'] as Map)['timeout'], 8000);
+    expect(
+      (providers['without-health-check'] as Map).containsKey('health-check'),
+      isFalse,
+    );
+  });
+
+  test('keeps an explicitly configured provider timeout', () {
+    final rawConfig = <String, dynamic>{
+      'proxy-providers': {
+        'provider': {
+          'health-check': <String, dynamic>{'timeout': 3000},
+        },
+      },
+    };
+
+    applyProviderHealthCheckTimeoutOverride(rawConfig, 8000);
+
+    final provider = (rawConfig['proxy-providers'] as Map)['provider'] as Map;
+    expect((provider['health-check'] as Map)['timeout'], 3000);
+  });
+}

--- a/test/models/ip_info_test.dart
+++ b/test/models/ip_info_test.dart
@@ -1,0 +1,11 @@
+import 'package:bett_box/models/common.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('keeps the detected IP when trace location is absent', () {
+    final info = IpInfo.fromCloudflareTrace('ip=203.0.113.10\n');
+
+    expect(info.ip, '203.0.113.10');
+    expect(info.countryCode, isEmpty);
+  });
+}

--- a/test/views/proxies/delay_test_coordinator_test.dart
+++ b/test/views/proxies/delay_test_coordinator_test.dart
@@ -1,10 +1,27 @@
 import 'dart:async';
 
+import 'package:bett_box/common/common.dart';
 import 'package:bett_box/models/models.dart';
 import 'package:bett_box/views/proxies/common.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('caps delay-test concurrency below the core queue limit', () {
+    expect(normalizeDelayTestConcurrency(0), 1);
+    expect(normalizeDelayTestConcurrency(16), 16);
+    expect(normalizeDelayTestConcurrency(250), maxDelayTestConcurrencyLimit);
+  });
+
+  test('maps delay failure values to non-sensitive categories', () {
+    expect(delayFailureLabel(delayTimeoutValue), 'Timeout');
+    expect(delayFailureLabel(delayDnsFailureValue), 'DNS');
+    expect(delayFailureLabel(delayTlsFailureValue), 'TLS');
+    expect(delayFailureLabel(delayHttpFailureValue), 'HTTP');
+    expect(delayFailureLabel(delayConnectFailureValue), 'Connect');
+    expect(delayFailureLabel(delayBridgeTimeoutValue), 'App timeout');
+    expect(delayFailureLabel(delayUnknownFailureValue), 'Failed');
+  });
+
   test('shares testing state and rejects overlapping group tests', () async {
     final coordinator = DelayTestCoordinator();
 


### PR DESCRIPTION
# 端口冲突与网络检测优化

## 变更摘要

本 PR 针对 Android 环境下的本地代理端口冲突、网络检测无法自动识别，以及代理测速结果误分类问题进行修复。

重点覆盖以下场景：

- 原版 Bettbox 与测试版同时运行时，本地 Mixed 端口被占用；
- 服务重连或旧服务未及时释放端口时，核心监听失败但应用仍继续显示运行状态；
- Android 已开启 VPN/TUN 时，网络检测仍依赖本地 Mixed 端口；
- 首次进入首页时自动网络检测未必触发；
- IP 已成功返回但地区字段缺失时，界面错误显示为检测失败；
- 手动测速地址与 proxy-provider 健康检查地址不一致；
- 不同类型的测速失败均被统一显示为 `Timeout`，不利于定位问题。

## 问题原因

### 1. Android 本地端口冲突

应用默认使用本地 Mixed 端口。当另一实例、旧服务进程或其他本地程序已经占用该端口时，Mihomo 会记录类似以下错误：

```text
Start Mixed(http+socks) server error: listen tcp 127.0.0.1:<PORT>: bind: address already in use
```

原有逻辑仍可能继续设置运行状态，导致后续内部 HTTP 请求、系统代理和网络检测继续访问一个无法正常使用的本地监听端口。

### 2. Android 网络检测依赖本地 Mixed 端口

Android 开启 VPN/TUN 后，网络检测请求本身可以直接由系统 VPN 路由到代理核心，不需要再经过应用层的本地 Mixed 端口。原有逻辑仍可能通过应用层代理访问本地端口，因此端口冲突会连带造成网络检测失败。

此外，首次检测状态使用了“正在加载”作为阻止条件，可能导致首次自动检测没有及时提交请求。

### 3. IP 信息解析过于严格

部分 trace 响应可能包含有效 IP，但缺少可选的地区字段。原有解析逻辑要求 IP 与地区字段同时存在，否则直接判定整个响应无效。

## 实现方案

### Android Mixed 端口自动避让

- Android 启动核心配置前检查首选本地端口是否可用；
- 首选端口被占用时，按顺序尝试后续可用端口；
- 连续端口均不可用时，回退到系统分配的本地端口；
- 当前运行周期内固定实际使用的端口，避免配置重复生成时端口不断变化；
- 停止核心后清理运行时端口状态；
- 内部 HTTP 代理和代理状态使用实际生效端口；
- 桌面平台保持原有端口行为不变；
- 不修改用户配置文件、节点地址或订阅地址。

### Android 网络检测路径调整

- Android 网络检测请求明确使用 `DIRECT`；
- 请求由 Android VPN/TUN 接管并按照当前代理状态路由；
- 网络检测不再依赖本地 Mixed 端口是否监听成功；
- 修正首次进入页面时的自动检测触发条件；
- 保留现有检测源和超时机制，不增加高频重试。

### IP 信息解析增强

- 当响应包含有效 IP 但缺少地区字段时，仍保留并显示 IP；
- 地区字段为空时不再把整次网络检测判定为失败。

### 代理测速与健康检查优化

- 开启“覆盖配置”时，同步覆盖已有 proxy-provider 健康检查的测试地址；
- 只修改配置中已经存在的健康检查，不自动创建新的健康检查；
- 健康检查超时仅在 provider 未明确设置超时时补充；
- provider 已配置的明确超时值保持不变；
- 延迟测试失败按 DNS、TLS、HTTP、连接、代理不可用、应用等待超时等类别展示；
- 不把原始异常文本、节点凭据或敏感地址直接显示到界面。

## 兼容性与范围

- 未修改 `lib/main.dart` 或 UI 启动初始化流程；
- 未修改 TUN、DNS、IPv6、Fake-IP、MTU 等网络栈默认策略；
- 未修改服务器、节点协议参数、UUID、密码、证书或订阅地址；
- 未引入无限重试或高频测速；
- Android 端端口避让属于运行时行为，不改变用户保存的端口设置；
- 当首选端口可用时，仍优先使用用户配置的端口；
- 桌面端保持原有 Mixed 端口逻辑。

## 验证结果

已完成以下验证：

- `go test .`：通过；
- Flutter 针对性测试：12 项全部通过；
- `flutter analyze --no-pub`：通过，无静态诊断问题；
- `flutter build apk --profile --target-platform android-arm64 --no-pub`：构建成功；
- APK v2 签名校验：通过；
- APK 测试包名和版本校验：通过；
- APK 内 arm64 Mihomo 核心与当前构建产物一致：通过；
- Git 差异检查：通过；
- 未发现启动文件、YAML、YML 或 TXT 配置文件被修改。

新增回归覆盖：

- 首选本地端口被占用时选择备用端口；
- 端口为 `0` 时保持禁用语义；
- trace 缺少地区字段时仍保留 IP；
- provider 健康检查超时覆盖逻辑；
- 延迟失败类别展示逻辑。

## 建议审核步骤

1. 在 Android 设备上同时保留原版 Bettbox 或其他占用首选端口的实例；
2. 启动本 PR 版本并开启代理，确认不再出现 Mixed 端口绑定错误；
3. 不点击手动刷新，等待首页网络检测自动返回 IP 信息；
4. 在 VPN/TUN 开启和关闭两种状态分别验证网络检测；
5. 使用一个日本节点和一个新加坡节点分别执行两次测速；
6. 对比 Apple 与公共 204 测试地址，确认失败类型能够区分，而不是全部显示为 `Timeout`；
7. 确认网页访问、代理切换、provider 更新和系统代理行为正常。

本人均已测试，功能正常。

## 隐私说明

本 PR 不包含：

- 个人配置文件；
- 订阅链接或 Token；
- 节点域名、地址、端口、UUID、密码或证书；
- ADB 日志、设备标识、截图或录屏；
- 个人测试数据和服务器信息。

该 PR 仅提交通用代码、公开测试逻辑和回归测试，不依赖任何个人订阅或服务器环境。
