### PR TITLE
fix: Linux 支持托盘图标左键单击

### DIFF
--- a/plugins/tray_manager/linux/tray_manager_plugin.cc
+++ b/plugins/tray_manager/linux/tray_manager_plugin.cc
@@ -222,6 +222,15 @@ GtkWidget* _create_menu(FlValue* args) {
   return menu;
 }
 
+#ifdef HAVE_AYATANA
+static void _on_indicator_activate(AppIndicator* indicator, gint x, gint y,
+                                   gpointer user_data) {
+  fl_method_channel_invoke_method(plugin_instance->channel,
+                                  "onTrayIconMouseDown", nullptr, nullptr,
+                                  nullptr, nullptr);
+}
+#endif
+
 static FlMethodResponse* destroy(TrayManagerPlugin* self, FlValue* args) {
   if (!(!indicator)) {
     app_indicator_set_status(indicator, APP_INDICATOR_STATUS_PASSIVE);
@@ -241,6 +250,13 @@ static FlMethodResponse* set_icon(TrayManagerPlugin* self, FlValue* args) {
   if (!indicator) {
     indicator = app_indicator_new(id, icon_path,
                                   APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+
+#ifdef HAVE_AYATANA
+    if (g_signal_lookup("activate", app_indicator_get_type()) != 0) {
+      g_signal_connect(G_OBJECT(indicator), "activate", G_CALLBACK(_on_indicator_activate),
+                       nullptr);
+    }
+#endif
 
     app_indicator_set_menu(indicator, GTK_MENU(menu));
     gtk_widget_show_all(menu);


### PR DESCRIPTION
### 问题

Linux 上左键单击托盘图标无响应，右键菜单正常。

### 根因

Dart 侧已有左键处理（ `lib/manager/tray_manager.dart:42` `onTrayIconMouseDown()` → `window?.show()`），但 vendored 的 tray_manager Linux 插件从未监听 ayatana-appindicator 的 `activate`（SNI `Activate` 主键）信号，因此该事件在 Linux 上从不触发。

### 改动

`plugins/tray_manager/linux/tray_manager_plugin.cc`：
- `HAVE_AYATANA` 下创建 indicator 后连接 `activate` 信号（tray_manager_plugin.cc:254-258），回调 `_on_indicator_activate` 向 Dart 发送 `onTrayIconMouseDown`（tray_manager_plugin.cc:225-232）。
- 用 `g_signal_lookup` 探测信号存在性，避免低版本 libayatana 连接非法信号。
- 已用系统头文件做过语法编译验证（g++ -fsyntax-only 通过）。

 
### 依赖与生效条件：

- activate 信号始于 ayatana-appindicator 0.6.0；0.5.x 及老版 libappindicator 无此信号，该分支被编译掉，左键回退为原行为。
- 即使有 0.6.0+，还需宿主 DE 发送 Activate（如 KDE/GNOME/Xfce）；部分宿主仍只会弹菜单。
- 已验证在 Arch Linux Niri + DMS shell 工作正常

---

By DeepSeek V4 Flash Free