### PR TITLE
fix: 修复 debug 构建下日志页 null 刷屏

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -1214,7 +1214,7 @@ class AppController {
   Future<void> init() async {
     FlutterError.onError = (details) {
       if (kDebugMode) {
-        commonPrint.log(details.stack.toString());
+        debugPrint('[FlutterError] ${details.exception}');
       }
     };
 

--- a/lib/widgets/list.dart
+++ b/lib/widgets/list.dart
@@ -649,29 +649,32 @@ class ContinuousListItem extends StatelessWidget {
         ),
       ),
       clipBehavior: Clip.antiAlias,
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final hasTightHeight = constraints.hasTightHeight;
-          return Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (hasTightHeight)
-                Expanded(
-                  child: Align(
-                    alignment: Alignment.center,
-                    child: child,
-                  ),
-                )
-              else
-                child,
-              Container(
-                height: 1,
-                margin: const EdgeInsets.symmetric(horizontal: 16),
-                color: isLast ? Colors.transparent : dividerColor,
-              ),
-            ],
-          );
-        },
+      child: Material(
+        type: MaterialType.transparency,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final hasTightHeight = constraints.hasTightHeight;
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (hasTightHeight)
+                  Expanded(
+                    child: Align(
+                      alignment: Alignment.center,
+                      child: child,
+                    ),
+                  )
+                else
+                  child,
+                Container(
+                  height: 1,
+                  margin: const EdgeInsets.symmetric(horizontal: 16),
+                  color: isLast ? Colors.transparent : dividerColor,
+                ),
+              ],
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
### 现象
debug 构建（`APP_DEV=true`）打开【日志】tab 后，控制台与日志列表持续高频刷出 `[APP] null`（实测约 2000+/25s），并且逐条自增长。

### 根因
一条自增殖循环：
1. 日志行 `LogItem` 把带 `focusColor` 的 `ListItem`（ListTile）包在 `ContinuousListItem` 的有色 `Container`（无 `Material`）中，每次构建触发 Flutter debug 断言：`ListTile background color or ink splashes may be invisible.`
2. 断言 → `FlutterError.onError`（`lib/controller.dart`）执行 `commonPrint.log(details.stack.toString())`；`details.stack` 为 `null`，`null.toString()` 返回字面量 `"null"`，于是打印 `[APP] null`。
3. `commonPrint.log` 又把这行写回日志列表 → 新增一行 → 重建 → 再次断言 → 无限循环。
「debug 构建」独有：错误处理器仅在 `kDebugMode` 下生效；同一断言也会在连接页、订阅页命中（三者共用 `ContinuousListItem`）。

### 改动
- `fix(ui) lib/widgets/list.dart`：`ContinuousListItem` 子节点包一层 `Material(type: MaterialType.transparency)`，消除断言，同时保证 ListTile 的 ink 效果能正确渲染（Flutter 官方推荐做法）。日志页 / 连接页 / 订阅页一并修复。
- `fix(logging) lib/controller.dart`：`FlutterError.onError` 改为 `debugPrint('[FlutterError] ${details.exception}')`——输出真实异常信息而非 `"null"`，且不再写回日志列表，切断自增殖。（release 行为不变。）

### 验证
- 修复前：`flutter run -d linux --debug --dart-define APP_DEV=true` 约 25s 内刷出数千条 `[APP] null`。
- 修复后：`[APP] null` 与断言均为 0，仅剩正常启动日志。

---

Assisted by Big Pickle.

This closes #407.