### PR TITLE
feat(profiles): 优化添加配置一级界面，统一为卡片式布局

### DIFF
--- a/lib/views/profiles/add_profile.dart
+++ b/lib/views/profiles/add_profile.dart
@@ -1,4 +1,5 @@
 import 'package:bett_box/common/common.dart';
+import 'package:bett_box/enum/enum.dart';
 import 'package:bett_box/models/models.dart';
 import 'package:bett_box/pages/scan.dart';
 import 'package:bett_box/state.dart';
@@ -99,30 +100,66 @@ class AddProfileView extends StatelessWidget {
   @override
   Widget build(context) {
     return ListView(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       children: [
-        ListItem(
-          leading: const Icon(Icons.qr_code_sharp),
-          title: Text(appLocalizations.qrcode),
-          subtitle: Text(appLocalizations.qrcodeDesc),
-          onTap: _toScan,
-        ),
-        ListItem(
-          leading: const Icon(Icons.content_paste),
-          title: Text(appLocalizations.clipboard),
-          subtitle: Text(appLocalizations.clipboardDesc),
-          onTap: _handleAddProfileFromClipboard,
-        ),
-        ListItem(
-          leading: const Icon(Icons.upload_file_sharp),
-          title: Text(appLocalizations.file),
-          subtitle: Text(appLocalizations.fileDesc),
-          onTap: _handleAddProfileFormFile,
-        ),
-        ListItem(
-          leading: const Icon(Icons.cloud_download_sharp),
-          title: Text(appLocalizations.url),
-          subtitle: Text(appLocalizations.urlDesc),
-          onTap: _toAdd,
+        CommonCard(
+          type: CommonCardType.filled,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListItem(
+                leading: const Icon(Icons.qr_code_sharp),
+                title: Text(appLocalizations.qrcode),
+                subtitle: Text(appLocalizations.qrcodeDesc),
+                onTap: _toScan,
+              ),
+              Divider(
+                height: 1,
+                thickness: 1,
+                color: context.colorScheme.outlineVariant.withValues(
+                  alpha: context.colorScheme.brightness == Brightness.light ? 0.6 : 0.45,
+                ),
+                indent: 16,
+                endIndent: 16,
+              ),
+              ListItem(
+                leading: const Icon(Icons.content_paste),
+                title: Text(appLocalizations.clipboard),
+                subtitle: Text(appLocalizations.clipboardDesc),
+                onTap: _handleAddProfileFromClipboard,
+              ),
+              Divider(
+                height: 1,
+                thickness: 1,
+                color: context.colorScheme.outlineVariant.withValues(
+                  alpha: context.colorScheme.brightness == Brightness.light ? 0.6 : 0.45,
+                ),
+                indent: 16,
+                endIndent: 16,
+              ),
+              ListItem(
+                leading: const Icon(Icons.upload_file_sharp),
+                title: Text(appLocalizations.file),
+                subtitle: Text(appLocalizations.fileDesc),
+                onTap: _handleAddProfileFormFile,
+              ),
+              Divider(
+                height: 1,
+                thickness: 1,
+                color: context.colorScheme.outlineVariant.withValues(
+                  alpha: context.colorScheme.brightness == Brightness.light ? 0.6 : 0.45,
+                ),
+                indent: 16,
+                endIndent: 16,
+              ),
+              ListItem(
+                leading: const Icon(Icons.cloud_download_sharp),
+                title: Text(appLocalizations.url),
+                subtitle: Text(appLocalizations.urlDesc),
+                onTap: _toAdd,
+              ),
+            ],
+          ),
         ),
       ],
     );


### PR DESCRIPTION
### 改动说明

- 使用 `CommonCard` 封装添加配置页的选项列表，统一应用内的卡片式 UI 风格。
- 增加外层边距与选项间分割线，未改动任何原有业务与导入逻辑。


<img width="718" height="1089" alt="屏幕截图 2026-09-02 165734" src="https://github.com/user-attachments/assets/48710983-55c7-44f4-bfad-e2988ad986b6" />
